### PR TITLE
Add `ommited` to content type field declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Version [1.1.2][unreleased] - (in development)
-- TBA
+## Version [1.2.0][unreleased] - (in development)
+- New: Add `omitted` field for content type fields.
 
 ## Version [1.1.1] - 2016-05-09
 - Fix: Redirect input query on async `ModuleSpaces` fetches.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Grab via Maven:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.contentful.java:cma-sdk:1.1.1'
+compile 'com.contentful.java:cma-sdk:1.2.0'
 ```
 
 The SDK requires at minimum Java 6 or Android 2.3.

--- a/src/main/java/com/contentful/java/cma/FieldTypeAdapter.java
+++ b/src/main/java/com/contentful/java/cma/FieldTypeAdapter.java
@@ -37,6 +37,7 @@ final class FieldTypeAdapter implements JsonSerializer<CMAField> {
   private static final String ATTR_LINK_TYPE = "linkType";
   private static final String ATTR_REQUIRED = "required";
   private static final String ATTR_DISABLED = "disabled";
+  private static final String ATTR_OMITTED = "omitted";
   private static final String ATTR_LOCALIZED = "localized";
   private static final String ATTR_VALIDATIONS = "validations";
   private static final String ATTR_ARRAY_ITEMS = "items";
@@ -51,6 +52,7 @@ final class FieldTypeAdapter implements JsonSerializer<CMAField> {
     add(json, ATTR_LINK_TYPE, field.getLinkType());
     add(json, ATTR_REQUIRED, field.isRequired());
     add(json, ATTR_DISABLED, field.isDisabled());
+    add(json, ATTR_OMITTED, field.isOmitted());
     add(json, ATTR_LOCALIZED, field.isLocalized());
 
     List<Map> validations = field.getValidations();

--- a/src/main/java/com/contentful/java/cma/model/CMAField.java
+++ b/src/main/java/com/contentful/java/cma/model/CMAField.java
@@ -52,11 +52,15 @@ public class CMAField {
   // Disabled
   boolean disabled;
 
+  // Omitted
+  boolean omitted;
+
   // Localized
   boolean localized;
 
   /**
    * Sets the ID for this field.
+   *
    * @param id the id to be set
    * @return this {@code CMAField} instance
    */
@@ -67,6 +71,7 @@ public class CMAField {
 
   /**
    * Sets the name for this field.
+   *
    * @param name the name to be set
    * @return this {@code CMAField} instance
    */
@@ -77,6 +82,7 @@ public class CMAField {
 
   /**
    * Sets the type for this field.
+   *
    * @param type the type to be set
    * @return this {@code CMAField} instance
    */
@@ -87,6 +93,7 @@ public class CMAField {
 
   /**
    * Sets the link type for this field.
+   *
    * @param linkType the type of link to be set
    * @return this {@code CMAField} instance
    */
@@ -139,6 +146,18 @@ public class CMAField {
    */
   public CMAField setDisabled(boolean disabled) {
     this.disabled = disabled;
+    return this;
+  }
+
+  /**
+   * Sets the {@code omitted} attribute value.
+   *
+   * @param omitted boolean indicating whether or not this field is complete omitted
+   *                Returns this {@code CMAField} instance
+   * @return this {@code CMAField} instance
+   */
+  public CMAField setOmitted(boolean omitted) {
+    this.omitted = omitted;
     return this;
   }
 
@@ -208,6 +227,13 @@ public class CMAField {
    */
   public Boolean isDisabled() {
     return disabled;
+  }
+
+  /**
+   * @return the {@code omitted} attribute of this field.
+   */
+  public Boolean isOmitted() {
+    return omitted;
   }
 
   /**

--- a/src/test/kotlin/com/contentful/java/cma/GeneralTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/GeneralTests.kt
@@ -21,15 +21,18 @@ class GeneralTests : BaseTest() {
 
         assertTrue(field.isRequired)
         assertTrue(field.isDisabled)
+        assertTrue(field.isOmitted)
 
         // True
         var json = gson!!.toJsonTree(field, CMAField::class.java).asJsonObject
         assertTrue(json.has("required"))
         assertTrue(json.has("disabled"))
+        assertTrue(json.has("omitted"))
 
         // False
         field.setRequired(false)
         field.setDisabled(false)
+        field.setOmitted(false)
 
         // General attributes
         json = gson!!.toJsonTree(field, CMAField::class.java).asJsonObject

--- a/src/test/resources/field_object.json
+++ b/src/test/resources/field_object.json
@@ -4,6 +4,7 @@
   "type": "Text",
   "required": true,
   "disabled": true,
+  "omitted": true,
   "validations": [
     {
       "size": {


### PR DESCRIPTION
enable reading/writing of `ommited` field in responses from CMA.