### PR TITLE
fix: serialise links the right way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add: Ability to track rate limit headers.
 - Fix: Return HTTP Code of no content methods.
 - Fix: Assets: Do not send `url` and `details` if `uploadUrl` or `uploadFrom` is changed.
+- Fix: Serialize Links correctly.
 - Polishing: Update dependencies
   - retrofit 2.3.0 (was 2.0.1)
   - commonsio 2.5 (was 2.4)

--- a/src/main/java/com/contentful/java/cma/gson/EntrySerializer.java
+++ b/src/main/java/com/contentful/java/cma/gson/EntrySerializer.java
@@ -92,18 +92,18 @@ public class EntrySerializer implements JsonSerializer<CMAEntry> {
       throw new IllegalArgumentException("Entry contains link to draft resource (has no ID).");
     }
 
-    CMAType type = resource.getSystem().getType();
-    if (type == null) {
+    CMAType linkedType = resource.getSystem().getLinkType();
+    if (linkedType == null) {
       if (resource instanceof CMAAsset) {
-        type = CMAType.Asset;
+        linkedType = CMAType.Asset;
       } else if (resource instanceof CMAEntry) {
-        type = CMAType.Entry;
+        linkedType = CMAType.Entry;
       }
     }
 
     JsonObject sys = new JsonObject();
     sys.addProperty("type", Link.toString());
-    sys.addProperty("linkType", type.toString());
+    sys.addProperty("linkType", linkedType.toString());
     sys.addProperty("id", id);
 
     JsonObject result = new JsonObject();

--- a/src/test/kotlin/com/contentful/java/cma/LinkTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/LinkTests.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Contentful GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.contentful.java.cma
+
+import com.contentful.java.cma.lib.TestUtils
+import com.contentful.java.cma.model.CMAEntry
+import com.contentful.java.cma.model.CMALink
+import com.contentful.java.cma.model.CMAType
+import okhttp3.mockwebserver.MockResponse
+import kotlin.test.assertTrue
+import org.junit.Test as test
+
+class LinkTests : BaseTest() {
+    @test fun testCreateLink() {
+        val requestBody = TestUtils.fileToString("asset_update_request.json")
+        server!!.enqueue(MockResponse().setResponseCode(200).setBody(requestBody))
+        val cmaLink = CMALink(CMAType.Asset).setId("linkedTargetId")
+
+        val cmaEntry = CMAEntry()
+        cmaEntry.localize("en-US").setField("link", cmaLink)
+
+        client!!.entries().create("spaceId", "contentTypeId", cmaEntry)
+
+        val cmaRequest = server!!.takeRequest()
+
+        val body = cmaRequest.body.readUtf8()
+        assertTrue(body.contains("\"id\":\"linkedTargetId\""))
+        assertTrue(body.contains("\"linkType\":\"Asset\""))
+        assertTrue(body.contains("\"type\":\"Link\""))
+    }
+}


### PR DESCRIPTION
Before we were always sending a linkedType of `Link` which is an error.