### PR TITLE
fix snapshots not containing snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Version [3.2.1] - (TBD)
+- Fix Snapshots to contain entries and content types
+
 ## Version [3.2.0] - (2018-11-12)
 - Add [rich text](https://www.contentful.com/developers/docs/concepts/rich-text/) management classes.
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Install the Contentful dependency:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.1</version>
 </dependency>
 ```
 
 * _Gradle_
 ```groovy
-compile 'com.contentful.java:cma-sdk:3.1.0'
+compile 'com.contentful.java:cma-sdk:3.2.1'
 ```
 
 This SDK requires Java 7 (or higher version) or Android 5.
@@ -262,14 +262,14 @@ Snapshots of the development version are available through
 
 ```groovy
 maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-compile 'com.contentful.java:cma-sdk:3.1.0-SNAPSHOT'
+compile 'com.contentful.java:cma-sdk:3.2.1-SNAPSHOT'
 ```
 
 * [jitpack.io](https://jitpack.io/#contentful/contentful-management.java/master-SNAPSHOT):
 
 ```groovy
 maven { url 'https://jitpack.io' }
-compile 'com.github.contentful:contentful.java:cma-sdk-3.1.0-SNAPSHOT'
+compile 'com.github.contentful:contentful.java:cma-sdk-3.2.1-SNAPSHOT'
 ```
 
 Documentation

--- a/src/main/java/com/contentful/java/cma/CMAClient.java
+++ b/src/main/java/com/contentful/java/cma/CMAClient.java
@@ -21,6 +21,7 @@ package com.contentful.java.cma;
 import com.contentful.java.cma.gson.EntrySerializer;
 import com.contentful.java.cma.gson.FieldTypeAdapter;
 import com.contentful.java.cma.gson.LocaleSerializer;
+import com.contentful.java.cma.gson.SnapshotDeserializer;
 import com.contentful.java.cma.interceptor.AuthorizationHeaderInterceptor;
 import com.contentful.java.cma.interceptor.ContentTypeInterceptor;
 import com.contentful.java.cma.interceptor.ContentfulUserAgentHeaderInterceptor;
@@ -35,6 +36,7 @@ import com.contentful.java.cma.interceptor.UserAgentHeaderInterceptor;
 import com.contentful.java.cma.model.CMAEntry;
 import com.contentful.java.cma.model.CMAField;
 import com.contentful.java.cma.model.CMALocale;
+import com.contentful.java.cma.model.CMASnapshot;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -165,6 +167,7 @@ public class CMAClient {
       gson = new GsonBuilder()
           .registerTypeAdapter(CMAField.class, new FieldTypeAdapter())
           .registerTypeAdapter(CMAEntry.class, new EntrySerializer())
+          .registerTypeAdapter(CMASnapshot.class, new SnapshotDeserializer())
           .registerTypeAdapter(CMALocale.class, new LocaleSerializer())
           .create();
     }

--- a/src/main/java/com/contentful/java/cma/gson/SnapshotDeserializer.java
+++ b/src/main/java/com/contentful/java/cma/gson/SnapshotDeserializer.java
@@ -1,0 +1,47 @@
+package com.contentful.java.cma.gson;
+
+import com.contentful.java.cma.model.CMAContentType;
+import com.contentful.java.cma.model.CMAEntry;
+import com.contentful.java.cma.model.CMASnapshot;
+import com.contentful.java.cma.model.CMASystem;
+import com.contentful.java.cma.model.CMAType;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+/**
+ * This class will take a json blob and deserialize a snapshot from it.
+ */
+public class SnapshotDeserializer implements JsonDeserializer<CMASnapshot> {
+
+  /**
+   * Inspect json payload and generate either a content type snapshot from it or an entry snap shot.
+   *
+   * @param json    the json blob to be converted
+   * @param typeOfT the type to be converted
+   * @param context the json context for updating
+   * @return a snapshot, parsed from the json
+   * @throws JsonParseException if the json object to be parsed is malformed.
+   */
+  @Override
+  public CMASnapshot deserialize(JsonElement json, Type
+      typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    final CMASnapshot result = new CMASnapshot();
+    final JsonObject jsonObject = json.getAsJsonObject();
+    final CMASystem system = context.deserialize(jsonObject.get("sys"), CMASystem.class);
+    result.setSystem(system);
+
+    final JsonObject snapshot = jsonObject.getAsJsonObject("snapshot");
+    final String type = snapshot.getAsJsonObject("sys").getAsJsonPrimitive("type").getAsString();
+    if (CMAType.ContentType.name().equals(type)) {
+      result.setSnapshot(context.deserialize(snapshot, CMAContentType.class));
+    } else if (CMAType.Entry.name().equals(type)) {
+      result.setSnapshot(context.deserialize(snapshot, CMAEntry.class));
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/contentful/java/cma/model/CMASnapshot.java
+++ b/src/main/java/com/contentful/java/cma/model/CMASnapshot.java
@@ -5,7 +5,7 @@ package com.contentful.java.cma.model;
  */
 public class CMASnapshot extends CMAResource {
 
-  CMAResource snapshot;
+  private CMAResource snapshot;
 
   /**
    * Create a new snapshot.
@@ -21,5 +21,15 @@ public class CMASnapshot extends CMAResource {
    */
   public CMAResource getSnapshot() {
     return snapshot;
+  }
+
+  /**
+   * Update the current snapshot.
+   *
+   * @param snapshot the value to be used.
+   */
+  public CMASnapshot setSnapshot(CMAResource snapshot) {
+    this.snapshot = snapshot;
+    return this;
   }
 }

--- a/src/test/kotlin/com/contentful/java/cma/ContentTypeTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/ContentTypeTests.kt
@@ -538,7 +538,8 @@ class ContentTypeTests{
         // Assert first item
         val first = items[0]
         assertEquals(CMAType.Snapshot, first.system.type)
-        assertEquals(CMAType.ContentType, first.snapshot.system.type)
+        assertTrue(first.snapshot is CMAContentType)
+        assertEquals(CMAType.ContentType, (first.snapshot as CMAContentType).system.type)
 
         // Request
         val recordedRequest = server!!.takeRequest()
@@ -560,7 +561,8 @@ class ContentTypeTests{
                 contentType, "snapShotId", TestCallback()) as TestCallback)!!
 
         assertEquals(CMAType.Snapshot, result.system.type)
-        assertEquals(CMAType.ContentType, result.snapshot.system.type)
+        assertTrue(result.snapshot is CMAContentType)
+        assertEquals(CMAType.ContentType, (result.snapshot as CMAContentType).system.type)
 
         // Request
         val recordedRequest = server!!.takeRequest()

--- a/src/test/kotlin/com/contentful/java/cma/EntryTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/EntryTests.kt
@@ -483,7 +483,8 @@ class EntryTests {
         // Assert first item
         val first = items[0]
         assertEquals(CMAType.Snapshot, first.system.type)
-        assertEquals(CMAType.Entry, first.snapshot.system.type)
+        assertTrue(first.snapshot is CMAEntry)
+        assertEquals(CMAType.Entry, (first.snapshot as CMAEntry).system.type)
 
         // Request
         val recordedRequest = server!!.takeRequest()
@@ -505,7 +506,8 @@ class EntryTests {
                 entry, "snapShotId", TestCallback()) as TestCallback)!!
 
         assertEquals(CMAType.Snapshot, result.system.type)
-        assertEquals(CMAType.Entry, result.snapshot.system.type)
+        assertTrue(result.snapshot is CMAEntry)
+        assertEquals(CMAType.Entry, (result.snapshot as CMAEntry).system.type)
 
         // Request
         val recordedRequest = server!!.takeRequest()

--- a/src/test/kotlin/com/contentful/java/cma/e2e/EntryE2E.kt
+++ b/src/test/kotlin/com/contentful/java/cma/e2e/EntryE2E.kt
@@ -44,6 +44,8 @@ open class EntryE2E : Base() {
 
     @Test
     fun testEntries() {
+        val initialEntryCount = client.entries().fetchAll().total
+
         var entry = CMAEntry()
         entry.setField("title", "en-US", "My Title")
 
@@ -58,6 +60,7 @@ open class EntryE2E : Base() {
         assertEquals(1, snapshots.items.size)
 
         val snapshot = client.entries().fetchOneSnapshot(entry, snapshots.items.first().id)
+        assertTrue(snapshot.snapshot is CMAEntry)
         assertEquals(snapshots.items.first().toString().trim(), snapshot.toString().trim())
 
         entry = client.entries().unPublish(entry)
@@ -79,6 +82,6 @@ open class EntryE2E : Base() {
 
         assertEquals(204, client.entries().delete(entry))
 
-        assertEquals(3, client.entries().fetchAll().total)
+        assertEquals(initialEntryCount, client.entries().fetchAll().total)
     }
 }


### PR DESCRIPTION
Currently the `.getSnapshot()`-method on a `CMASnapshot` does only return a shallow `CMAResource` but not the underlying `CMAContentType` or `CMAEntry`, making only the `.system()` fields accessible.

This PR updates the behaviour in also parsing the `snapshot` payload from the json, deserializing either entry or a content type.

Shout out to [ykryshchuk](https://www.contentfulcommunity.com/t/cma-java-fetch-snapshots/1550/2) for finding it.