### PR TITLE
rich text e2e: update all the elements of a rich text field

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Install the Contentful dependency:
 compile 'com.contentful.java:cma-sdk:3.2.2'
 ```
 
-This SDK requires Java 7 (or higher version) or Android 5.
+This SDK requires Java 8 (or higher version).
 
 Client Creation
 ---------------
@@ -235,23 +235,7 @@ The SDK uses [Retrofit][2] as a REST client, which detects [OkHttp][3] in the cl
 
 The recommended approach would be to add [OkHttp][3] as a dependency to your project, but that is completely optional.
 
-YIt is possible to specify a custom client to be used, refer to the [official documentation][4] for instructions.
-
-ProGuard
---------
-
-The following lines are the start of a `proguard` file used for minifying Android distributions.
-https://github.com/contentful/contentful-management.java/pull/110#issuecomment-411362987)Ou
-```
--keepattributes Signature
--dontwarn rx.**
--dontwarn retrofit.**
--keep class retrofit.** { *; }
--keep class com.contentful.java.cma.** { *; }
--keep class com.google.gson.** { *; }
--keep class sun.misc.Unsafe { *; }
-```
-
+It is possible to specify a custom client to be used, refer to the [official documentation][4] for instructions.
 
 Pre-releases
 ------------

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,11 @@
     <retrofit.version>2.5.0</retrofit.version>
 
     <!-- Test Dependencies -->
-    <commonsio.version>2.5</commonsio.version>
+    <commonsio.version>2.6</commonsio.version>
     <junit.version>4.12</junit.version>
-    <kotlin.version>1.2.31</kotlin.version>
+    <kotlin.version>1.3.11</kotlin.version>
     <okhttp.version>3.12.1</okhttp.version>
-    <rxjava.version>2.1.1</rxjava.version>
+    <rxjava.version>2.2.5</rxjava.version>
     <android.version>4.1.1.4</android.version>
     <android.platform>16</android.platform>
     <robolectric.version>2.4</robolectric.version>

--- a/src/main/java/com/contentful/java/cma/gson/EntrySerializer.java
+++ b/src/main/java/com/contentful/java/cma/gson/EntrySerializer.java
@@ -109,37 +109,43 @@ public class EntrySerializer implements JsonSerializer<CMAEntry>, JsonDeserializ
 
   private JsonElement serializeRichNode(JsonSerializationContext context, CMARichNode node) {
     if (node instanceof CMARichHyperLink) {
-      final CMARichHyperLink link = (CMARichHyperLink) node;
-      final JsonObject jsonLink = freshGson.toJsonTree(link).getAsJsonObject();
-
-      jsonLink.addProperty("nodeType", link.getNodeType());
-
-      final Map<String, Object> data = new LinkedHashMap<>(1);
-      if (link.getData() instanceof CMAResource) {
-        data.put("target", toLink(context, (CMAResource) link.getData()));
-      } else {
-        data.put("uri", link.getData());
-        data.remove("target");
-      }
-
-      jsonLink.add("data", context.serialize(data));
-      return jsonLink;
-
+      return serializeRichHyperlink(context, (CMARichHyperLink) node);
     } else if (node instanceof CMARichBlock) {
-      final CMARichBlock block = (CMARichBlock) node;
-      final JsonObject jsonBlock = freshGson.toJsonTree(block).getAsJsonObject();
-
-      final JsonArray jsonContent = new JsonArray(block.getContent().size());
-      for (final CMARichNode contentNode : block.getContent()) {
-        jsonContent.add(serializeRichNode(context, contentNode));
-      }
-
-      jsonBlock.add("content", jsonContent);
-
-      return jsonBlock;
+      return serializeRichBlock(context, (CMARichBlock) node);
     } else {
       return context.serialize(node);
     }
+  }
+
+  private JsonElement serializeRichBlock(JsonSerializationContext context, CMARichBlock block) {
+    final JsonObject jsonBlock = freshGson.toJsonTree(block).getAsJsonObject();
+
+    final JsonArray jsonContent = new JsonArray(block.getContent().size());
+    for (final CMARichNode contentNode : block.getContent()) {
+      jsonContent.add(serializeRichNode(context, contentNode));
+    }
+
+    jsonBlock.add("content", jsonContent);
+
+    return jsonBlock;
+  }
+
+  private JsonElement serializeRichHyperlink(JsonSerializationContext context,
+                                             CMARichHyperLink link) {
+    final JsonObject jsonLink = freshGson.toJsonTree(link).getAsJsonObject();
+
+    jsonLink.addProperty("nodeType", link.getNodeType());
+
+    final Map<String, Object> data = new LinkedHashMap<>(1);
+    if (link.getData() instanceof CMAResource) {
+      data.put("target", toLink(context, (CMAResource) link.getData()));
+    } else {
+      data.put("uri", link.getData());
+      data.remove("target");
+    }
+
+    jsonLink.add("data", context.serialize(data));
+    return jsonLink;
   }
 
   private JsonObject toLink(JsonSerializationContext context, CMAResource resource) {

--- a/src/main/java/com/contentful/java/cma/model/rich/CMARichEmbeddedLink.java
+++ b/src/main/java/com/contentful/java/cma/model/rich/CMARichEmbeddedLink.java
@@ -9,13 +9,25 @@ import com.contentful.java.cma.model.CMAType;
  * @see com.contentful.java.cma.model.CMAEntry
  */
 public class CMARichEmbeddedLink extends CMARichHyperLink {
+  private final transient boolean inline;
+
+  /**
+   * Create a link pointing to a CMAEntry.
+   *
+   * @param target an entry to be pointed to.
+   */
+  public CMARichEmbeddedLink(Object target, boolean inline) {
+    super(target);
+    this.inline = inline;
+  }
+
   /**
    * Create a link pointing to a CMAEntry.
    *
    * @param target an entry to be pointed to.
    */
   public CMARichEmbeddedLink(Object target) {
-    super(target);
+    this(target, false);
   }
 
   /**
@@ -24,10 +36,12 @@ public class CMARichEmbeddedLink extends CMARichHyperLink {
   @Override public String getNodeType() {
     if (data instanceof CMALink) {
       final CMAType linkType = ((CMALink) data).getSystem().getLinkType();
+      final String block = inline ? "inline" : "block";
+
       if (linkType == CMAType.Asset) {
-        return "embedded-asset-block";
+        return "embedded-asset-" + block;
       } else if (linkType == CMAType.Entry) {
-        return "embedded-entry-block";
+        return "embedded-entry-" + block;
       }
     }
     return super.getNodeType();

--- a/src/main/java/com/contentful/java/cma/model/rich/CMARichHeading.java
+++ b/src/main/java/com/contentful/java/cma/model/rich/CMARichHeading.java
@@ -6,7 +6,7 @@ package com.contentful.java.cma.model.rich;
  * Can have an arbitrary level assigned, but useful probably between 1 and 6.
  */
 public class CMARichHeading extends CMARichBlock {
-  private final int level;
+  private final transient int level;
 
   /**
    * Create a heading block, describing a level elements deep nested heading.

--- a/src/main/java/com/contentful/java/cma/model/rich/CMARichHorizontalRule.java
+++ b/src/main/java/com/contentful/java/cma/model/rich/CMARichHorizontalRule.java
@@ -1,9 +1,14 @@
 package com.contentful.java.cma.model.rich;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A node representing a division, called a horizontal rule.
  */
 public class CMARichHorizontalRule extends CMARichNode {
+  private List<String> content = new ArrayList<>();
+
   /**
    * Construct a horizontal rule node.
    */

--- a/src/main/java/com/contentful/java/cma/model/rich/RichTextFactory.java
+++ b/src/main/java/com/contentful/java/cma/model/rich/RichTextFactory.java
@@ -196,10 +196,10 @@ public class RichTextFactory {
         new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
     RESOLVER_MAP.put(new CMARichEmbeddedLink(new CMALink(CMAType.Asset)).getNodeType(),
         new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
-    RESOLVER_MAP.put("embedded-entry-inline", new BlockAndDataResolver<>(CMARichEmbeddedLink::new,
-        "data"));
-    RESOLVER_MAP.put("embedded-asset-inline", new BlockAndDataResolver<>(CMARichEmbeddedLink::new,
-        "data"));
+    RESOLVER_MAP.put(new CMARichEmbeddedLink(new CMALink(CMAType.Entry), true).getNodeType(),
+        new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
+    RESOLVER_MAP.put(new CMARichEmbeddedLink(new CMALink(CMAType.Asset), true).getNodeType(),
+        new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
     RESOLVER_MAP.put(new CMARichHeading(LEVEL_1).getNodeType(), new HeadingResolver(LEVEL_1));
     RESOLVER_MAP.put(new CMARichHeading(LEVEL_2).getNodeType(), new HeadingResolver(LEVEL_2));
     RESOLVER_MAP.put(new CMARichHeading(LEVEL_3).getNodeType(), new HeadingResolver(LEVEL_3));

--- a/src/test/kotlin/com/contentful/java/cma/e2e/RichTextE2E.kt
+++ b/src/test/kotlin/com/contentful/java/cma/e2e/RichTextE2E.kt
@@ -19,18 +19,18 @@ package com.contentful.java.cma.e2e
 import com.contentful.java.cma.model.CMAEntry
 import com.contentful.java.cma.model.CMALink
 import com.contentful.java.cma.model.CMAType
-import com.contentful.java.cma.model.rich.CMARichDocument
-import com.contentful.java.cma.model.rich.CMARichHyperLink
-import com.contentful.java.cma.model.rich.CMARichParagraph
-import com.contentful.java.cma.model.rich.CMARichText
+import com.contentful.java.cma.model.rich.*
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 open class RichTextE2E : Base() {
     @Test
     fun testRichTextTexts() {
-        val previousItemCount = client.entries().fetchAll().total
+        val previousItemCount = client.entries().fetchAll(
+                mapOf("limit" to "0")
+        ).total
 
         val richText = CMARichDocument().addContent(
                 CMARichParagraph().addContent(
@@ -133,9 +133,394 @@ open class RichTextE2E : Base() {
         assertEquals(204, client.entries().delete(entry))
         assertEquals(previousItemCount, client.entries().fetchAll().total)
     }
+
+    @Test
+    fun testRichDocument() {
+        val richText = CMARichDocument()
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(0, richResult.content.size)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichEmbeddedLink() {
+        val richText = document(
+                CMARichParagraph()
+                        .addContent(
+                                CMARichEmbeddedLink(
+                                        CMALink(
+                                                client.entries().fetchAll(
+                                                        mapOf("limit" to "1")
+                                                ).items.first()
+                                        ), true
+                                )
+                        )
+        )
+
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val richParagraph = richResult.content.first()
+        assertNotNull(richParagraph as CMARichParagraph)
+        assertEquals(1, richParagraph.content.size)
+
+        val resultLink = richParagraph.content.first()
+        assertNotNull(resultLink as CMARichEmbeddedLink)
+        val resultData = resultLink.data
+        assertNotNull(resultData as CMALink)
+        assertNotNull(resultData.id)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichHeading() {
+        val richText = document(CMARichHeading(5).addContent(CMARichText("Heading of level 5.")))
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultHeading = richResult.content.first()
+        assertNotNull(resultHeading as CMARichHeading)
+        assertEquals(5, resultHeading.level)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichHorizontalRule() {
+        val richText = CMARichDocument().addContent(CMARichHorizontalRule())
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultLink = richResult.content.first()
+        assertTrue(resultLink is CMARichHorizontalRule)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichHyperLink() {
+        val richText = CMARichDocument()
+                .addContent(
+                        CMARichParagraph()
+                                .addContent(
+                                        CMARichHyperLink("https://foobarbaz")
+                                )
+                )
+
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val richParagraph = richResult.content.first()
+        assertNotNull(richParagraph as CMARichParagraph)
+        assertEquals(1, richParagraph.content.size)
+
+        val resultLink = richParagraph.content.first()
+        assertNotNull(resultLink as CMARichHyperLink)
+        assertEquals("https://foobarbaz", resultLink.data)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichListItem() {
+        val richText = document(
+                CMARichOrderedList()
+                        .addContent(
+                                CMARichListItem()
+                                        .addContent(
+                                                CMARichParagraph().addContent(
+                                                        CMARichText("listitem")
+                                                )
+                                        )
+                        )
+        )
+
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultList = richResult.content.first()
+        assertNotNull(resultList as CMARichOrderedList)
+        assertEquals(1, resultList.content.size)
+
+        val resultItem = resultList.content.first()
+        assertNotNull(resultItem as CMARichListItem)
+        assertEquals(1, resultItem.content.size)
+
+        val resultParagraph = resultItem.content.first()
+        assertNotNull(resultParagraph as CMARichParagraph)
+        assertEquals("listitem", (resultParagraph.content.first() as CMARichText).value)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichOrderedList() {
+        val richText = document(
+                CMARichOrderedList()
+                        .addContent(
+                                CMARichListItem()
+                                        .addContent(
+                                                CMARichParagraph()
+                                                        .addContent(
+                                                                CMARichText("first")
+                                                        )
+                                        ),
+                                CMARichListItem()
+                                        .addContent(
+                                                CMARichParagraph()
+                                                        .addContent(
+                                                                CMARichText("second")
+                                                        )
+                                        )
+                        )
+        )
+
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultList = richResult.content.first()
+        assertNotNull(resultList as CMARichOrderedList)
+        assertEquals(2, resultList.content.size)
+
+        val first = resultList.content.first()
+        assertNotNull(first as CMARichListItem)
+        assertEquals("first", (
+                (first.content.first() as CMARichParagraph).content.first() as CMARichText).value
+        )
+
+        val second = resultList.content.second()
+        assertNotNull(second as CMARichListItem)
+        assertEquals("second", (
+                (second.content.first() as CMARichParagraph).content.first() as CMARichText).value
+        )
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichParagraph() {
+        val richText = document(CMARichParagraph().addContent(CMARichText("some text")))
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultParagraph = richResult.content.first()
+        assertNotNull(resultParagraph as CMARichParagraph)
+        assertEquals(1, resultParagraph.content.size)
+
+        val resultText = resultParagraph.content.first()
+        assertNotNull(resultText as CMARichText)
+        assertEquals("some text", resultText.value)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichQuote() {
+        val richText = document(
+                CMARichQuote()
+                        .addContent(
+                                CMARichParagraph()
+                                        .addContent(
+                                                CMARichText(
+                                                        "rich quote from someone"
+                                                )
+                                        )
+                        )
+        )
+
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultQuote = richResult.content.first()
+        assertNotNull(resultQuote as CMARichQuote)
+        assertEquals(1, resultQuote.content.size)
+
+        val resultParagraph = resultQuote.content.first()
+        assertNotNull(resultParagraph as CMARichParagraph)
+        assertEquals(1, resultParagraph.content.size)
+
+        val resultText = resultParagraph.content.first()
+        assertNotNull(resultText as CMARichText)
+        assertEquals("rich quote from someone", resultText.value)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichText() {
+        val richText = document(CMARichParagraph().addContent(CMARichText("test text")))
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        val richResult = result.getField<CMARichDocument>("rich_text", "en-US")
+        assertNotNull(richResult as CMARichDocument)
+        assertEquals(1, richResult.content.size)
+
+        val resultParagraph = richResult.content.first()
+        assertNotNull(resultParagraph as CMARichParagraph)
+        assertEquals(1, resultParagraph.content.size)
+
+        val resultText = resultParagraph.content.first()
+        assertNotNull(resultText as CMARichText)
+        assertEquals("test text", resultText.value)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
+
+    @Test
+    fun testRichUnorderedList() {
+        val richText = document(CMARichUnorderedList())
+        val entry = CMAEntry()
+        entry.setField("title", "en-US", "rich text title")
+        entry.setField("rich_text", "en-US", richText)
+
+        var result = client.entries().create("theOnlyContentModel", entry)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+
+        result = client.entries().publish(result)
+
+        assertNotNull(result)
+        assertEquals(entry::class, result::class)
+    }
 }
 
-private fun <T> List<T>.second(): T {
+internal fun document(child: CMARichNode): CMARichNode =
+        CMARichDocument()
+                .addContent(
+                        child
+                )
+
+internal fun <T> List<T>.second(): T {
     if (isEmpty())
         throw NoSuchElementException("List is empty.")
     if (size < 2)

--- a/src/test/kotlin/com/contentful/java/cma/e2e/RolesE2E.kt
+++ b/src/test/kotlin/com/contentful/java/cma/e2e/RolesE2E.kt
@@ -17,7 +17,6 @@
 package com.contentful.java.cma.e2e
 
 import com.contentful.java.cma.CMAClient
-import com.contentful.java.cma.model.CMARole
 import org.junit.BeforeClass
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -44,17 +43,5 @@ open class RolesE2E : Base() {
     fun testRoles() {
         val roles = client.roles().fetchAll().items
         assertEquals(0, roles.size)
-
-//        var role = client.roles().fetchOne(roles.first().id)
-//        assertEquals("test role", role.name)
-//        assertEquals("test description", role.description)
-//
-//        role.name = "test role 2"
-//        role = client.roles().update(role)
-//        assertEquals("test role 2", role.name)
-//
-//        val result = client.roles().delete(role)
-//        assertEquals(204, result)
-
     }
 }


### PR DESCRIPTION
This PR is to track progress on #118: Updating rich text through this SDK.

|SDK class | passes e2e test |
|-----|--------|
|CMARichDocument | ☑
|CMARichEmbeddedLink | ☑
|CMARichHeading | ☑
|CMARichHorizontalRule | ☑
|CMARichHyperLink | ☑
|CMARichListItem | ☑
|CMARichMark | ☑
|CMARichNode | ☑
|CMARichOrderedList | ☑
|CMARichParagraph | ☑
|CMARichQuote | ☑
|CMARichText | ☑
|CMARichUnorderedList | ☑