### PR TITLE
Issue with `inline` hyperlink inside nested paragraph

### DIFF
--- a/src/main/java/com/contentful/java/cma/model/rich/RichTextFactory.java
+++ b/src/main/java/com/contentful/java/cma/model/rich/RichTextFactory.java
@@ -197,9 +197,9 @@ public class RichTextFactory {
     RESOLVER_MAP.put(new CMARichEmbeddedLink(new CMALink(CMAType.Asset)).getNodeType(),
         new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
     RESOLVER_MAP.put(new CMARichEmbeddedLink(new CMALink(CMAType.Entry), true).getNodeType(),
-        new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
+        new BlockAndDataResolver<>(target -> new CMARichEmbeddedLink(target, true), "data"));
     RESOLVER_MAP.put(new CMARichEmbeddedLink(new CMALink(CMAType.Asset), true).getNodeType(),
-        new BlockAndDataResolver<>(CMARichEmbeddedLink::new, "data"));
+        new BlockAndDataResolver<>(target -> new CMARichEmbeddedLink(target, true), "data"));
     RESOLVER_MAP.put(new CMARichHeading(LEVEL_1).getNodeType(), new HeadingResolver(LEVEL_1));
     RESOLVER_MAP.put(new CMARichHeading(LEVEL_2).getNodeType(), new HeadingResolver(LEVEL_2));
     RESOLVER_MAP.put(new CMARichHeading(LEVEL_3).getNodeType(), new HeadingResolver(LEVEL_3));

--- a/src/test/kotlin/com/contentful/java/cma/RichFieldTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/RichFieldTests.kt
@@ -873,4 +873,31 @@ class RichFieldTests {
 
         assertEquals(listOf("This ", "is", "some", "simple", "nested", "list"), traverse(list))
     }
+
+    @test
+    fun testNestedParaghraphWithInlineLink() {
+        val responseBody = TestUtils.fileToString("rich_text_get_all.json")
+        server!!.enqueue(MockResponse().setResponseCode(200).setBody(responseBody))
+        val array = assertTestCallback(client!!.entries().async().fetchAll(
+                TestCallback()) as TestCallback)!!
+
+        val result = array.items.first {
+            it.getField<String>("name", "en-US") == "nested_paragraph_with_inline_link"
+        }
+
+        val document = result.getField<CMARichDocument>("rich", "en-US")
+        assertNotNull(document)
+
+        val topParagraph = document.content.first() as CMARichParagraph
+        assertNotNull(topParagraph)
+        assertEquals(1, topParagraph.content.size)
+
+        val nestedParagraph = topParagraph.content.first() as CMARichParagraph
+        assertNotNull(nestedParagraph)
+        assertEquals(3, nestedParagraph.content.size)
+
+        val inlineEmbeddedEntryLink = nestedParagraph.content[1] as CMARichHyperLink
+        assertTrue(inlineEmbeddedEntryLink is CMARichEmbeddedLink)
+        assertEquals("embedded-entry-inline", inlineEmbeddedEntryLink.nodeType)
+    }
 }

--- a/src/test/resources/rich_text_get_all.json
+++ b/src/test/resources/rich_text_get_all.json
@@ -2936,6 +2936,123 @@
           }
         }
       }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "<space_id>"
+          }
+        },
+        "id": "NestedParagraphWithInlineLink",
+        "type": "Entry",
+        "createdAt": "2018-10-17T13:32:26.729Z",
+        "updatedAt": "2019-01-09T13:29:01.276Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "publishedCounter": 5,
+        "version": 15,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "publishedVersion": 14,
+        "firstPublishedAt": "2018-10-17T13:32:27.340Z",
+        "publishedAt": "2019-01-09T13:29:01.276Z",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "rich"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "nested_paragraph_with_inline_link"
+        },
+        "rich": {
+          "en-US": {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": ".",
+                    "nodeType": "Text before nested paragraph"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "Text in the beginning of nested paragraph",
+                        "nodeType": "text"
+                      },
+                      {
+                        "data": {
+                          "target": {
+                            "sys": {
+                              "id": "RRarwhlUXtnXO1H4gla58",
+                              "type": "Link",
+                              "linkType": "Entry"
+                            }
+                          }
+                        },
+                        "content": [],
+                        "nodeType": "embedded-entry-inline"
+                      },
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "Text in the end of nested paragraph",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "paragraph"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": ".",
+                    "nodeType": "Text after nested paragraph"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "document"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
If we have a paragraph inside another paragraph and the inner paragraph contains `embedded-entry-inline` block than this block is parsed as `CMARichEmbeddedLink` with false `inline` flag 

~~Just test to prove the issue, no fix so far~~

The fix is committed