### PR TITLE
Fix map parameter mutation

### DIFF
--- a/src/main/java/com/contentful/java/cma/DefaultQueryParameter.java
+++ b/src/main/java/com/contentful/java/cma/DefaultQueryParameter.java
@@ -33,12 +33,19 @@ class DefaultQueryParameter {
    *
    * @param target   the map to be filled with values, if a key for them is not set already.
    * @param defaults the list of defaults, to be set.
+   * @return the same map if no change had to be made, a new map otherwise.
    */
-  static void putIfNotSet(Map<String, String> target, Map<String, String> defaults) {
-    for (final String key : defaults.keySet()) {
-      if (!target.containsKey(key)) {
-        target.put(key, defaults.get(key));
+  static Map<String, String> putIfNotSet(Map<String, String> target, Map<String, String> defaults) {
+    boolean needsChange = defaults.keySet().stream().anyMatch(key -> !target.containsKey(key));
+    if (needsChange) {
+      Map<String, String> copy = new HashMap<>(target);
+      for (final String key : defaults.keySet()) {
+        if (!copy.containsKey(key)) {
+          copy.put(key, defaults.get(key));
+        }
       }
+      return copy;
     }
+    return target;
   }
 }

--- a/src/main/java/com/contentful/java/cma/ModuleAssets.java
+++ b/src/main/java/com/contentful/java/cma/ModuleAssets.java
@@ -210,9 +210,9 @@ public class ModuleAssets extends AbsModule<ServiceAssets> {
       Map<String, String> query) {
     assertNotNull(spaceId, "spaceId");
     assertNotNull(environmentId, "environmentId");
-    DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
-
-    return service.fetchAll(spaceId, environmentId, query).blockingFirst();
+    Map<String, String> enhancedQuery =
+      DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
+    return service.fetchAll(spaceId, environmentId, enhancedQuery).blockingFirst();
   }
 
   /**

--- a/src/main/java/com/contentful/java/cma/ModuleContentTypes.java
+++ b/src/main/java/com/contentful/java/cma/ModuleContentTypes.java
@@ -202,8 +202,9 @@ public class ModuleContentTypes extends AbsModule<ServiceContentTypes> {
       String environmentId,
       Map<String, String> query) {
     assertNotNull(spaceId, "spaceId");
-    DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
-    return service.fetchAll(spaceId, environmentId, query).blockingFirst();
+    Map<String, String> enhancedQuery =
+      DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
+    return service.fetchAll(spaceId, environmentId, enhancedQuery).blockingFirst();
   }
 
   /**

--- a/src/main/java/com/contentful/java/cma/ModuleEntries.java
+++ b/src/main/java/com/contentful/java/cma/ModuleEntries.java
@@ -233,8 +233,9 @@ public class ModuleEntries extends AbsModule<ServiceEntries> {
     assertNotNull(spaceId, "spaceId");
     assertNotNull(environmentId, "environmentId");
 
-    DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
-    return service.fetchAll(spaceId, environmentId, query).blockingFirst();
+    Map<String, String> enhancedQuery =
+      DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
+    return service.fetchAll(spaceId, environmentId, enhancedQuery).blockingFirst();
   }
 
   /**

--- a/src/main/java/com/contentful/java/cma/ModuleSpaces.java
+++ b/src/main/java/com/contentful/java/cma/ModuleSpaces.java
@@ -166,8 +166,9 @@ public class ModuleSpaces extends AbsModule<ServiceSpaces> {
    * @return {@link CMAArray} result instance
    */
   public CMAArray<CMASpace> fetchAll(Map<String, String> query) {
-    DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
-    return service.fetchAll(query).blockingFirst();
+    Map<String, String> enhancedQuery =
+      DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
+    return service.fetchAll(enhancedQuery).blockingFirst();
   }
 
   /**
@@ -347,8 +348,9 @@ public class ModuleSpaces extends AbsModule<ServiceSpaces> {
                                                     CMACallback<CMAArray<CMASpace>> callback) {
       return defer(new DefFunc<CMAArray<CMASpace>>() {
         @Override CMAArray<CMASpace> method() {
-          DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
-          return ModuleSpaces.this.fetchAll(query);
+          Map<String, String> enhancedQuery =
+            DefaultQueryParameter.putIfNotSet(query, DefaultQueryParameter.FETCH);
+          return ModuleSpaces.this.fetchAll(enhancedQuery);
         }
       }, callback);
     }

--- a/src/test/kotlin/com/contentful/java/cma/DefaultQueryParameterTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/DefaultQueryParameterTests.kt
@@ -27,31 +27,31 @@ class DefaultQueryParameterTests {
     @test
     fun testEmptyMapWithDefaults() {
         val defaultMap = hashMapOf(Pair(MAP_KEY, MAP_VALUE))
-        val targetMap = HashMap<String, String>()
+        val targetMap = mapOf<String, String>()
 
-        DefaultQueryParameter.putIfNotSet(targetMap, defaultMap)
+        val resultingMap = DefaultQueryParameter.putIfNotSet(targetMap, defaultMap)
 
-        assertEquals(targetMap[MAP_KEY], MAP_VALUE)
+        assertEquals(resultingMap[MAP_KEY], MAP_VALUE)
     }
 
     @test
     fun testDoNotOverwriteValueWithDefaultValue() {
         val defaultMap = hashMapOf(Pair(MAP_KEY, MAP_VALUE))
-        val targetMap = hashMapOf(Pair(MAP_KEY, "NON_DEFAULT_VALUE"))
+        val targetMap = mapOf(Pair(MAP_KEY, "NON_DEFAULT_VALUE"))
 
-        DefaultQueryParameter.putIfNotSet(targetMap, defaultMap)
+        val resultingMap = DefaultQueryParameter.putIfNotSet(targetMap, defaultMap)
 
-        assertEquals(targetMap[MAP_KEY], "NON_DEFAULT_VALUE")
+        assertEquals(resultingMap[MAP_KEY], "NON_DEFAULT_VALUE")
     }
 
     @test
     fun testDoNotChangeDifferentValues() {
         val defaultMap = hashMapOf(Pair(MAP_KEY + "_123", "SOMETHING"))
-        val targetMap = hashMapOf(Pair(MAP_KEY, MAP_VALUE))
+        val targetMap = mapOf(Pair(MAP_KEY, MAP_VALUE))
 
-        DefaultQueryParameter.putIfNotSet(targetMap, defaultMap)
+        val resultingMap = DefaultQueryParameter.putIfNotSet(targetMap, defaultMap)
 
-        assertEquals(targetMap[MAP_KEY], MAP_VALUE)
-        assertEquals(targetMap[MAP_KEY + "_123"], "SOMETHING")
+        assertEquals(resultingMap[MAP_KEY], MAP_VALUE)
+        assertEquals(resultingMap[MAP_KEY + "_123"], "SOMETHING")
     }
 }


### PR DESCRIPTION
Hi,

I encountered this issue while trying to use the SDK with immutable maps such as:
```java
List<CMAEntry> matchingItems = client.entries().fetchAll(Map.of("param", value)).getItems();
```

Mutable maps are still useable, so the change should be backwardcompatible with previous versions of the SDK.