### PR TITLE
Use highest abstraction level in API

### DIFF
--- a/src/main/java/com/contentful/java/cma/model/CMAField.java
+++ b/src/main/java/com/contentful/java/cma/model/CMAField.java
@@ -16,12 +16,12 @@
 
 package com.contentful.java.cma.model;
 
-import com.contentful.java.cma.Constants.CMAFieldType;
-import com.google.gson.annotations.SerializedName;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.contentful.java.cma.Constants.CMAFieldType;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * CMAField.
@@ -176,7 +176,7 @@ public class CMAField {
   /**
    * @return the {@code items} attribute value as a {@code Map}.
    */
-  public HashMap<String, Object> getArrayItems() {
+  public Map<String, Object> getArrayItems() {
     return arrayItems;
   }
 
@@ -186,8 +186,8 @@ public class CMAField {
    * @param arrayItems Map instance
    * @return this {@code CMAField} instance
    */
-  public CMAField setArrayItems(HashMap<String, Object> arrayItems) {
-    this.arrayItems = arrayItems;
+  public CMAField setArrayItems(Map<String, Object> arrayItems) {
+    this.arrayItems = new HashMap<>(arrayItems);
     return this;
   }
 

--- a/src/test/kotlin/com/contentful/java/cma/GeneralTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/GeneralTests.kt
@@ -79,7 +79,7 @@ class GeneralTests{
     @test
     fun testFieldArraySerialization() {
         val field = CMAField().setType(CMAFieldType.Array)
-                .setArrayItems(hashMapOf(Pair("type", CMAFieldType.Symbol.toString())))
+                .setArrayItems(mapOf(Pair("type", CMAFieldType.Symbol.toString())))
 
         val json = gson!!.toJsonTree(field, CMAField::class.java).asJsonObject
         assertEquals("Array", json.get("type").asString)


### PR DESCRIPTION
It is good practice to expose only the highest abstraction level needed
(see SOLID principles, and more specifically the
[Dependency inversion principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle)).

This change makes it possible to construct an array content-type using Java 9+ `Map#of`.

Such as :
```java
new CMAField()
    .setId("key")
    .setName("key")
    .setType(Constants.CMAFieldType.Array)
    .setArrayItems(Map.of("type", Constants.CMAFieldType.Symbol))
```

`HashMap` are still useable, so the change should be backwardcompatible with previous versions of the SDK.