### PR TITLE
feat: Cross space referencing implementation

### DIFF
--- a/src/main/java/com/contentful/java/cma/Constants.java
+++ b/src/main/java/com/contentful/java/cma/Constants.java
@@ -43,6 +43,7 @@ public final class Constants {
     Date,
     Integer,
     Link,
+    ResourceLink,
     Location,
     Number,
     Object,

--- a/src/main/java/com/contentful/java/cma/model/CMAField.java
+++ b/src/main/java/com/contentful/java/cma/model/CMAField.java
@@ -42,6 +42,9 @@ public class CMAField {
   // Validations
   List<Map<String, Object>> validations;
 
+  // Allowed resources
+  List<Map<String, Object>> allowedResources;
+
   // Array Items
   @SerializedName("items")
   HashMap<String, Object> arrayItems;
@@ -172,6 +175,27 @@ public class CMAField {
     this.validations = validations;
     return this;
   }
+
+  /**
+   * @return a {@code List} of allowed resources.
+   */
+  public List<Map<String, Object>> getAllowedResources() {
+    return allowedResources;
+  }
+
+  /**
+   * Sets a {@code List} of allowed resources for this field.
+   *
+   * @param allowedResources allowed resources list
+   *                    Returns this {@code CMAField} instance
+   * @return this {@code CMAField} instance
+   */
+
+  public CMAField setAllowedResources(List<Map<String, Object>> allowedResources) {
+    this.allowedResources = allowedResources;
+    return this;
+  }
+
 
   /**
    * @return the {@code items} attribute value as a {@code Map}.

--- a/src/main/java/com/contentful/java/cma/model/CMASystem.java
+++ b/src/main/java/com/contentful/java/cma/model/CMASystem.java
@@ -29,6 +29,7 @@ public class CMASystem {
   Integer version;
   CMAVisibility visibility;
   CMALink organization;
+  String urn;
 
   public CMAVisibility getVisibility() {
     return visibility;
@@ -180,6 +181,20 @@ public class CMASystem {
   }
 
   /**
+   * @return The identifier of the resource.
+   */
+  public String getUrn() {
+    return urn;
+  }
+
+  /**
+   * Updates the identifier of the resource.
+   */
+  public void setUrn(String urn) {
+    this.urn = urn;
+  }
+
+  /**
    * Update this type.
    * <p>
    * This method is especially usefull for creating new resources before uploading them.
@@ -275,6 +290,7 @@ public class CMASystem {
     map.put("version", getVersion());
     map.put("status", getEnvironmentalStatus());
     map.put("visibility", getVisibility());
+    map.put("urn", getUrn());
 
     final StringBuilder builder = new StringBuilder("CMASystem { ");
     String separator = "";


### PR DESCRIPTION
This adds support for [https://www.contentful.com/developers/docs/references/content-management-api-eap/#/reference/cross-space-referencing/create-the-field-type-in-a-content-type](https://www.contentful.com/developers/docs/references/content-management-api-eap/#/reference/cross-space-referencing/create-the-field-type-in-a-content-type)