### PR TITLE
Remove leading slashes for paths within ServiceXYZ interfaces

### DIFF
--- a/src/main/java/com/contentful/java/cma/ServiceApiKeys.java
+++ b/src/main/java/com/contentful/java/cma/ServiceApiKeys.java
@@ -36,33 +36,33 @@ import retrofit2.http.QueryMap;
  * Api Token Service.
  */
 interface ServiceApiKeys {
-  @GET("/spaces/{spaceId}/api_keys")
+  @GET("spaces/{spaceId}/api_keys")
   Flowable<CMAArray<CMAApiKey>> fetchAll(@Path("spaceId") String spaceId);
 
-  @GET("/spaces/{spaceId}/api_keys")
+  @GET("spaces/{spaceId}/api_keys")
   Flowable<CMAArray<CMAApiKey>> fetchAll(
       @Path("spaceId") String spaceId,
       @QueryMap Map<String, String> query
   );
 
-  @GET("/spaces/{spaceId}/api_keys/{keyId}")
+  @GET("spaces/{spaceId}/api_keys/{keyId}")
   Flowable<CMAApiKey> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("keyId") String keyId);
 
-  @POST("/spaces/{spaceId}/api_keys")
+  @POST("spaces/{spaceId}/api_keys")
   Flowable<CMAApiKey> create(
       @Path("spaceId") String spaceId,
       @Body CMAApiKey key);
 
-  @PUT("/spaces/{spaceId}/api_keys/{keyId}")
+  @PUT("spaces/{spaceId}/api_keys/{keyId}")
   Flowable<CMAApiKey> update(
       @Header("X-Contentful-Version") Integer version,
       @Path("spaceId") String spaceId,
       @Path("keyId") String keyId,
       @Body CMAApiKey key);
 
-  @DELETE("/spaces/{spaceId}/api_keys/{keyId}")
+  @DELETE("spaces/{spaceId}/api_keys/{keyId}")
   Flowable<Response<Void>> delete(
       @Path("spaceId") String spaceId,
       @Path("keyId") String keyId);

--- a/src/main/java/com/contentful/java/cma/ServiceContentTags.java
+++ b/src/main/java/com/contentful/java/cma/ServiceContentTags.java
@@ -34,34 +34,34 @@ import java.util.Map;
  */
 interface ServiceContentTags {
 
-  @GET("/spaces/{space_id}/environments/{environment_id}/tags")
+  @GET("spaces/{space_id}/environments/{environment_id}/tags")
   Flowable<CMAArray<CMATag>> fetchAll(
       @Path("space_id") String spaceId,
       @Path("environment_id") String environmentID,
       @QueryMap Map<String, String> query
   );
-  @PUT("/spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
+  @PUT("spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
   Flowable<CMATag> create(
           @Path("space_id") String spaceId,
           @Path("environment_id") String environmentID,
           @Path("tag_id") String tagId,
           @Body CMATag tag);
 
-  @GET("/spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
+  @GET("spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
   Flowable<CMATag> fetchOne(
       @Path("space_id") String spaceId,
       @Path("environment_id") String environmentID,
       @Path("tag_id") String tagId
   );
 
-  @PUT("/spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
+  @PUT("spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
   Flowable<CMATag> update(
           @Path("space_id") String spaceId,
           @Path("environment_id") String environmentID,
           @Path("tag_id") String tagId,
           @Body CMATag tag);
 
-  @DELETE("/spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
+  @DELETE("spaces/{space_id}/environments/{environment_id}/tags/{tag_id}")
   Flowable<Response<Void>> delete(
           @Path("space_id") String spaceId,
           @Path("environment_id") String environmentID,

--- a/src/main/java/com/contentful/java/cma/ServiceContentTypes.java
+++ b/src/main/java/com/contentful/java/cma/ServiceContentTypes.java
@@ -37,44 +37,44 @@ import retrofit2.http.QueryMap;
  * ContentTypes Service.
  */
 interface ServiceContentTypes {
-  @POST("/spaces/{space}/environments/{environment}/content_types")
+  @POST("spaces/{space}/environments/{environment}/content_types")
   Flowable<CMAContentType> create(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Body CMAContentType contentType);
 
-  @PUT("/spaces/{space}/environments/{environment}/content_types/{content_type}")
+  @PUT("spaces/{space}/environments/{environment}/content_types/{content_type}")
   Flowable<CMAContentType> create(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("content_type") String contentTypeId,
       @Body CMAContentType contentType);
 
-  @DELETE("/spaces/{space}/environments/{environment}/content_types/{content_type}")
+  @DELETE("spaces/{space}/environments/{environment}/content_types/{content_type}")
   Flowable<Response<Void>> delete(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("content_type") String contentTypeId);
 
-  @GET("/spaces/{space}/environments/{environment}/content_types")
+  @GET("spaces/{space}/environments/{environment}/content_types")
   Flowable<CMAArray<CMAContentType>> fetchAll(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @QueryMap Map<String, String> query);
 
-  @GET("/spaces/{space}/environments/{environment}/content_types/{contentTypeId}/snapshots")
+  @GET("spaces/{space}/environments/{environment}/content_types/{contentTypeId}/snapshots")
   Flowable<CMAArray<CMASnapshot>> fetchAllSnapshots(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("contentTypeId") String contentTypeId);
 
-  @GET("/spaces/{space}/environments/{environment}/content_types/{content_type}")
+  @GET("spaces/{space}/environments/{environment}/content_types/{content_type}")
   Flowable<CMAContentType> fetchOne(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("content_type") String contentTypeId);
 
-  @GET("/spaces/{space}/environments/{environment}"
+  @GET("spaces/{space}/environments/{environment}"
       + "/content_types/{contentTypeId}/snapshots/{snapshotId}")
   Flowable<CMASnapshot> fetchOneSnapshot(
       @Path("space") String spaceId,
@@ -82,20 +82,20 @@ interface ServiceContentTypes {
       @Path("contentTypeId") String contentTypeId,
       @Path("snapshotId") String snapshotId);
 
-  @PUT("/spaces/{space}/environments/{environment}/content_types/{content_type}/published")
+  @PUT("spaces/{space}/environments/{environment}/content_types/{content_type}/published")
   Flowable<CMAContentType> publish(
       @Header("X-Contentful-Version") Integer version,
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("content_type") String contentTypeId);
 
-  @DELETE("/spaces/{space}/environments/{environment}/content_types/{content_type}/published")
+  @DELETE("spaces/{space}/environments/{environment}/content_types/{content_type}/published")
   Flowable<CMAContentType> unPublish(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("content_type") String contentTypeId);
 
-  @PUT("/spaces/{space}/environments/{environment}/content_types/{content_type}")
+  @PUT("spaces/{space}/environments/{environment}/content_types/{content_type}")
   Flowable<CMAContentType> update(
       @Header("X-Contentful-Version") Integer version,
       @Path("space") String spaceId,

--- a/src/main/java/com/contentful/java/cma/ServiceEditorInterfaces.java
+++ b/src/main/java/com/contentful/java/cma/ServiceEditorInterfaces.java
@@ -29,14 +29,14 @@ import retrofit2.http.Path;
  * Editor Interfaces Service.
  */
 interface ServiceEditorInterfaces {
-  @GET("/spaces/{space}/environments/{environment}/content_types/{contentType}/editor_interface")
+  @GET("spaces/{space}/environments/{environment}/content_types/{contentType}/editor_interface")
   Flowable<CMAEditorInterface> fetchOne(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("contentType") String contentTypeId
   );
 
-  @PUT("/spaces/{space}/environments/{environment}/content_types/{contentType}/editor_interface")
+  @PUT("spaces/{space}/environments/{environment}/content_types/{contentType}/editor_interface")
   Flowable<CMAEditorInterface> update(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,

--- a/src/main/java/com/contentful/java/cma/ServiceEntries.java
+++ b/src/main/java/com/contentful/java/cma/ServiceEntries.java
@@ -37,26 +37,26 @@ import retrofit2.http.QueryMap;
  * Entries Service.
  */
 interface ServiceEntries {
-  @PUT("/spaces/{space}/environments/{environment}/entries/{entry}/archived")
+  @PUT("spaces/{space}/environments/{environment}/entries/{entry}/archived")
   Flowable<CMAEntry> archive(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @DELETE("/spaces/{space}/environments/{environment}/entries/{entry}/archived")
+  @DELETE("spaces/{space}/environments/{environment}/entries/{entry}/archived")
   Flowable<CMAEntry> unArchive(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @POST("/spaces/{space}/environments/{environment}/entries")
+  @POST("spaces/{space}/environments/{environment}/entries")
   Flowable<CMAEntry> create(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Header("X-Contentful-Content-Type") String contentType,
       @Body CMAEntry entry);
 
-  @PUT("/spaces/{space}/environments/{environment}/entries/{entry}")
+  @PUT("spaces/{space}/environments/{environment}/entries/{entry}")
   Flowable<CMAEntry> create(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
@@ -64,51 +64,51 @@ interface ServiceEntries {
       @Path("entry") String entryId,
       @Body CMAEntry entry);
 
-  @DELETE("/spaces/{space}/environments/{environment}/entries/{entry}")
+  @DELETE("spaces/{space}/environments/{environment}/entries/{entry}")
   Flowable<Response<Void>> delete(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @GET("/spaces/{space}/environments/{environment}/entries/{entry}")
+  @GET("spaces/{space}/environments/{environment}/entries/{entry}")
   Flowable<CMAEntry> fetchOne(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @GET("/spaces/{space}/environments/{environment}/entries/{entry}/snapshots/{snapshot}")
+  @GET("spaces/{space}/environments/{environment}/entries/{entry}/snapshots/{snapshot}")
   Flowable<CMASnapshot> fetchOneSnapshot(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId,
       @Path("snapshot") String snapshotId);
 
-  @GET("/spaces/{space}/environments/{environment}/entries")
+  @GET("spaces/{space}/environments/{environment}/entries")
   Flowable<CMAArray<CMAEntry>> fetchAll(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @QueryMap Map<String, String> query);
 
-  @GET("/spaces/{space}/environments/{environment}/entries/{entry}/snapshots")
+  @GET("spaces/{space}/environments/{environment}/entries/{entry}/snapshots")
   Flowable<CMAArray<CMASnapshot>> fetchAllSnapshots(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @PUT("/spaces/{space}/environments/{environment}/entries/{entry}/published")
+  @PUT("spaces/{space}/environments/{environment}/entries/{entry}/published")
   Flowable<CMAEntry> publish(
       @Header("X-Contentful-Version") Integer version,
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @DELETE("/spaces/{space}/environments/{environment}/entries/{entry}/published")
+  @DELETE("spaces/{space}/environments/{environment}/entries/{entry}/published")
   Flowable<CMAEntry> unPublish(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
       @Path("entry") String entryId);
 
-  @PUT("/spaces/{space}/environments/{environment}/entries/{entry}")
+  @PUT("spaces/{space}/environments/{environment}/entries/{entry}")
   Flowable<CMAEntry> update(
       @Header("X-Contentful-Version") Integer version,
       @Path("space") String spaceId,

--- a/src/main/java/com/contentful/java/cma/ServiceEnvironments.java
+++ b/src/main/java/com/contentful/java/cma/ServiceEnvironments.java
@@ -32,48 +32,48 @@ import retrofit2.http.Path;
  * Environments Service.
  */
 interface ServiceEnvironments {
-  @POST("/spaces/{spaceId}/environments")
+  @POST("spaces/{spaceId}/environments")
   Flowable<CMAEnvironment> create(
       @Path("spaceId") String spaceId,
       @Body CMAEnvironment environment);
 
-  @POST("/spaces/{spaceId}/environments")
+  @POST("spaces/{spaceId}/environments")
   Flowable<CMAEnvironment> clone(
       @Path("spaceId") String spaceId,
       @Header("X-Contentful-Source-Environment") String sourceEnvironmentId,
       @Body CMAEnvironment environment);
 
-  @PUT("/spaces/{spaceId}/environments/{environmentId}")
+  @PUT("spaces/{spaceId}/environments/{environmentId}")
   Flowable<CMAEnvironment> create(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
       @Body CMAEnvironment environment);
 
-  @PUT("/spaces/{spaceId}/environments/{environmentId}")
+  @PUT("spaces/{spaceId}/environments/{environmentId}")
   Flowable<CMAEnvironment> clone(
       @Path("spaceId") String spaceId,
       @Header("X-Contentful-Source-Environment") String sourceEnvironmentId,
       @Path("environmentId") String environmentId,
       @Body CMAEnvironment environment);
 
-  @DELETE("/spaces/{spaceId}/environments/{environmentId}")
+  @DELETE("spaces/{spaceId}/environments/{environmentId}")
   Flowable<Response<Void>> delete(
       @Header("X-Contentful-Version") Integer version,
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId);
 
-  @GET("/spaces/{spaceId}/environments")
+  @GET("spaces/{spaceId}/environments")
   Flowable<CMAArray<CMAEnvironment>> fetchAll(
       @Path("spaceId") String spaceId
   );
 
-  @GET("/spaces/{spaceId}/environments/{environmentId}")
+  @GET("spaces/{spaceId}/environments/{environmentId}")
   Flowable<CMAEnvironment> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId
   );
 
-  @PUT("/spaces/{spaceId}/environments/{environmentId}")
+  @PUT("spaces/{spaceId}/environments/{environmentId}")
   Flowable<CMAEnvironment> update(
       @Header("X-Contentful-Version") Integer version,
       @Path("spaceId") String spaceId,

--- a/src/main/java/com/contentful/java/cma/ServiceLocales.java
+++ b/src/main/java/com/contentful/java/cma/ServiceLocales.java
@@ -17,27 +17,27 @@ import retrofit2.http.Path;
  * Service class to define the REST interface to Contentful.
  */
 public interface ServiceLocales {
-  @GET("/spaces/{spaceId}/environments/{environmentId}/locales")
+  @GET("spaces/{spaceId}/environments/{environmentId}/locales")
   Flowable<CMAArray<CMALocale>> fetchAll(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId
   );
 
-  @GET("/spaces/{spaceId}/environments/{environmentId}/locales/{localeId}")
+  @GET("spaces/{spaceId}/environments/{environmentId}/locales/{localeId}")
   Flowable<CMALocale> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
       @Path("localeId") String localeId
   );
 
-  @POST("/spaces/{spaceId}/environments/{environmentId}/locales/")
+  @POST("spaces/{spaceId}/environments/{environmentId}/locales/")
   Flowable<CMALocale> create(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
       @Body CMALocale locale
   );
 
-  @PUT("/spaces/{spaceId}/environments/{environmentId}/locales/{localeId}")
+  @PUT("spaces/{spaceId}/environments/{environmentId}/locales/{localeId}")
   Flowable<CMALocale> update(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
@@ -46,7 +46,7 @@ public interface ServiceLocales {
       @Header("X-Contentful-Version") Integer version
   );
 
-  @DELETE("/spaces/{spaceId}/environments/{environmentId}/locales/{localeId}")
+  @DELETE("spaces/{spaceId}/environments/{environmentId}/locales/{localeId}")
   Flowable<Response<Void>> delete(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,

--- a/src/main/java/com/contentful/java/cma/ServiceOrganizationUsage.java
+++ b/src/main/java/com/contentful/java/cma/ServiceOrganizationUsage.java
@@ -11,12 +11,12 @@ import java.util.Map;
 
 public interface ServiceOrganizationUsage {
 
-    @GET("/organizations/{organization_id}/organization_periodic_usages")
+    @GET("organizations/{organization_id}/organization_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId
     );
 
-    @GET("/organizations/{organization_id}/organization_periodic_usages")
+    @GET("organizations/{organization_id}/organization_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId,
             @QueryMap Map<String, String> query

--- a/src/main/java/com/contentful/java/cma/ServiceOrganizations.java
+++ b/src/main/java/com/contentful/java/cma/ServiceOrganizations.java
@@ -29,10 +29,10 @@ import retrofit2.http.QueryMap;
  * Organizations Service.
  */
 interface ServiceOrganizations {
-  @GET("/organizations")
+  @GET("organizations")
   Flowable<CMAArray<CMAOrganization>> fetchAll();
 
-  @GET("/organizations")
+  @GET("organizations")
   Flowable<CMAArray<CMAOrganization>> fetchAll(@QueryMap Map<String, String> query);
 }
 

--- a/src/main/java/com/contentful/java/cma/ServicePersonalAccessTokens.java
+++ b/src/main/java/com/contentful/java/cma/ServicePersonalAccessTokens.java
@@ -33,18 +33,18 @@ import retrofit2.http.QueryMap;
  * Personal Access Token Service.
  */
 interface ServicePersonalAccessTokens {
-  @GET("/users/me/access_tokens")
+  @GET("users/me/access_tokens")
   Flowable<CMAArray<CMAPersonalAccessToken>> fetchAll();
 
-  @GET("/users/me/access_tokens")
+  @GET("users/me/access_tokens")
   Flowable<CMAArray<CMAPersonalAccessToken>> fetchAll(@QueryMap Map<String, String> query);
 
-  @GET("/users/me/access_tokens/{tokenId}")
+  @GET("users/me/access_tokens/{tokenId}")
   Flowable<CMAPersonalAccessToken> fetchOne(@Path("tokenId") String tokenId);
 
-  @POST("/users/me/access_tokens")
+  @POST("users/me/access_tokens")
   Flowable<CMAPersonalAccessToken> create(@Body CMAPersonalAccessToken token);
 
-  @PUT("/users/me/access_tokens/{tokenId}/revoked")
+  @PUT("users/me/access_tokens/{tokenId}/revoked")
   Flowable<CMAPersonalAccessToken> revoke(@Path("tokenId") String tokenId);
 }

--- a/src/main/java/com/contentful/java/cma/ServicePreviewApiKeys.java
+++ b/src/main/java/com/contentful/java/cma/ServicePreviewApiKeys.java
@@ -27,10 +27,10 @@ import retrofit2.http.Path;
  * Preview Api Token Service.
  */
 interface ServicePreviewApiKeys {
-  @GET("/spaces/{spaceId}/preview_api_keys")
+  @GET("spaces/{spaceId}/preview_api_keys")
   Flowable<CMAArray<CMAPreviewApiKey>> fetchAll(@Path("spaceId") String spaceId);
 
-  @GET("/spaces/{spaceId}/preview_api_keys/{keyId}")
+  @GET("spaces/{spaceId}/preview_api_keys/{keyId}")
   Flowable<CMAPreviewApiKey> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("keyId") String keyId);

--- a/src/main/java/com/contentful/java/cma/ServiceRoles.java
+++ b/src/main/java/com/contentful/java/cma/ServiceRoles.java
@@ -20,28 +20,28 @@ import retrofit2.http.QueryMap;
  * Service class to define the REST interface to Contentful.
  */
 public interface ServiceRoles {
-  @GET("/spaces/{spaceId}/roles")
+  @GET("spaces/{spaceId}/roles")
   Flowable<CMAArray<CMARole>> fetchAll(@Path("spaceId") String spaceId);
 
-  @GET("/spaces/{spaceId}/roles")
+  @GET("spaces/{spaceId}/roles")
   Flowable<CMAArray<CMARole>> fetchAll(
       @Path("spaceId") String spaceId,
       @QueryMap Map<String, String> query
   );
 
-  @GET("/spaces/{spaceId}/roles/{roleId}")
+  @GET("spaces/{spaceId}/roles/{roleId}")
   Flowable<CMARole> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("roleId") String roleId
   );
 
-  @POST("/spaces/{spaceId}/roles/")
+  @POST("spaces/{spaceId}/roles/")
   Flowable<CMARole> create(
       @Path("spaceId") String spaceId,
       @Body CMARole role
   );
 
-  @PUT("/spaces/{spaceId}/roles/{roleId}")
+  @PUT("spaces/{spaceId}/roles/{roleId}")
   Flowable<CMARole> update(
       @Path("spaceId") String spaceId,
       @Path("roleId") String roleId,
@@ -49,7 +49,7 @@ public interface ServiceRoles {
       @Header("X-Contentful-Version") Integer version
   );
 
-  @DELETE("/spaces/{spaceId}/roles/{roleId}")
+  @DELETE("spaces/{spaceId}/roles/{roleId}")
   Flowable<Response<Void>> delete(
       @Path("spaceId") String spaceId,
       @Path("roleId") String roleId

--- a/src/main/java/com/contentful/java/cma/ServiceSpaceMemberships.java
+++ b/src/main/java/com/contentful/java/cma/ServiceSpaceMemberships.java
@@ -20,28 +20,28 @@ import retrofit2.http.QueryMap;
  * Service class to define the REST interface to Contentful.
  */
 public interface ServiceSpaceMemberships {
-  @GET("/spaces/{spaceId}/space_memberships")
+  @GET("spaces/{spaceId}/space_memberships")
   Flowable<CMAArray<CMASpaceMembership>> fetchAll(@Path("spaceId") String spaceId);
 
-  @GET("/spaces/{spaceId}/space_memberships")
+  @GET("spaces/{spaceId}/space_memberships")
   Flowable<CMAArray<CMASpaceMembership>> fetchAll(
       @Path("spaceId") String spaceId,
       @QueryMap Map<String, String> query
   );
 
-  @GET("/spaces/{spaceId}/space_memberships/{membershipId}")
+  @GET("spaces/{spaceId}/space_memberships/{membershipId}")
   Flowable<CMASpaceMembership> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("membershipId") String membershipId
   );
 
-  @POST("/spaces/{spaceId}/space_memberships")
+  @POST("spaces/{spaceId}/space_memberships")
   Flowable<CMASpaceMembership> create(
       @Path("spaceId") String spaceId,
       @Body CMASpaceMembership membership
   );
 
-  @PUT("/spaces/{spaceId}/space_memberships/{membershipId}")
+  @PUT("spaces/{spaceId}/space_memberships/{membershipId}")
   Flowable<CMASpaceMembership> update(
       @Path("spaceId") String spaceId,
       @Path("membershipId") String membershipId,
@@ -49,7 +49,7 @@ public interface ServiceSpaceMemberships {
       @Header("X-Contentful-Version") Integer version
   );
 
-  @DELETE("/spaces/{spaceId}/space_memberships/{membershipId}")
+  @DELETE("spaces/{spaceId}/space_memberships/{membershipId}")
   Flowable<Response<Void>> delete(
       @Path("spaceId") String spaceId,
       @Path("membershipId") String membershipId

--- a/src/main/java/com/contentful/java/cma/ServiceSpaceUsage.java
+++ b/src/main/java/com/contentful/java/cma/ServiceSpaceUsage.java
@@ -10,12 +10,12 @@ import retrofit2.http.QueryMap;
 import java.util.Map;
 
 public interface ServiceSpaceUsage {
-    @GET("/organizations/{organization_id}/space_periodic_usages")
+    @GET("organizations/{organization_id}/space_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId
     );
 
-    @GET("/organizations/{organization_id}/space_periodic_usages")
+    @GET("organizations/{organization_id}/space_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId,
             @QueryMap Map<String, String> query

--- a/src/main/java/com/contentful/java/cma/ServiceSpaces.java
+++ b/src/main/java/com/contentful/java/cma/ServiceSpaces.java
@@ -36,29 +36,29 @@ import retrofit2.http.QueryMap;
  * Spaces Service.
  */
 interface ServiceSpaces {
-  @POST("/spaces")
+  @POST("spaces")
   Flowable<CMASpace> create(
       @Body CMASpace space);
 
-  @POST("/spaces")
+  @POST("spaces")
   Flowable<CMASpace> create(
       @Header("X-Contentful-Organization") String organization,
       @Body CMASpace space);
 
-  @DELETE("/spaces/{space}")
+  @DELETE("spaces/{space}")
   Flowable<Response<Void>> delete(
       @Path("space") String spaceId);
 
-  @GET("/spaces")
+  @GET("spaces")
   Flowable<CMAArray<CMASpace>> fetchAll(
       @QueryMap Map<String, String> query
   );
 
-  @GET("/spaces/{space}")
+  @GET("spaces/{space}")
   Flowable<CMASpace> fetchOne(
       @Path("space") String spaceId);
 
-  @PUT("/spaces/{space}")
+  @PUT("spaces/{space}")
   Flowable<CMASpace> update(
       @Header("X-Contentful-Version") Integer version,
       @Path("space") String spaceId,

--- a/src/main/java/com/contentful/java/cma/ServiceUiExtensions.java
+++ b/src/main/java/com/contentful/java/cma/ServiceUiExtensions.java
@@ -36,34 +36,34 @@ import retrofit2.http.QueryMap;
  * Ui Extensions Service.
  */
 interface ServiceUiExtensions {
-  @GET("/spaces/{spaceId}/environments/{environmentId}/extensions")
+  @GET("spaces/{spaceId}/environments/{environmentId}/extensions")
   Flowable<CMAArray<CMAUiExtension>> fetchAll(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId
   );
 
-  @GET("/spaces/{spaceId}/environments/{environmentId}/extensions")
+  @GET("spaces/{spaceId}/environments/{environmentId}/extensions")
   Flowable<CMAArray<CMAUiExtension>> fetchAll(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
       @QueryMap Map<String, String> query
   );
 
-  @GET("/spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
+  @GET("spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
   Flowable<CMAUiExtension> fetchOne(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
       @Path("extensionId") String extensionId
   );
 
-  @POST("/spaces/{spaceId}/environments/{environmentId}/extensions")
+  @POST("spaces/{spaceId}/environments/{environmentId}/extensions")
   Flowable<CMAUiExtension> create(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
       @Body CMAUiExtension extension
   );
 
-  @PUT("/spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
+  @PUT("spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
   Flowable<CMAUiExtension> create(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
@@ -71,7 +71,7 @@ interface ServiceUiExtensions {
       @Body CMAUiExtension extension
   );
 
-  @PUT("/spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
+  @PUT("spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
   Flowable<CMAUiExtension> update(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,
@@ -80,7 +80,7 @@ interface ServiceUiExtensions {
       @Header("X-Contentful-Version") Integer version
   );
 
-  @DELETE("/spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
+  @DELETE("spaces/{spaceId}/environments/{environmentId}/extensions/{extensionId}")
   Flowable<Response<Void>> delete(
       @Path("spaceId") String spaceId,
       @Path("environmentId") String environmentId,

--- a/src/main/java/com/contentful/java/cma/ServiceUsers.java
+++ b/src/main/java/com/contentful/java/cma/ServiceUsers.java
@@ -25,6 +25,6 @@ import retrofit2.http.GET;
  * Users Service.
  */
 interface ServiceUsers {
-  @GET("/users/me")
+  @GET("users/me")
   Flowable<CMAUser> fetchMe();
 }


### PR DESCRIPTION
Remove leading slashes for paths within ServiceXYZ interfaces to support Builder.setCoreEndpoint() values with additional path e.g https://myproxy.com/proxy-contentful-api/ otherwise retrofit is ignoring the /proxy-contentful-api/ part. This is e.g. already the case for ServiceAssets.java, ServiceUploads.java and ServiceWebhooks.java.