### PR TITLE
feat: [JAVA-278] Increase chunk size

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -109,7 +109,7 @@
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MagicNumber">
-            <property name="ignoreNumbers" value="-1,0,1,2,10,100,255,16777215"/>
+            <property name="ignoreNumbers" value="-1,0,1,2,10,100,255,1024,16777215"/>
         </module>
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>

--- a/src/main/java/com/contentful/java/cma/ModuleUploads.java
+++ b/src/main/java/com/contentful/java/cma/ModuleUploads.java
@@ -73,7 +73,7 @@ public class ModuleUploads extends AbsModule<ServiceUploads> {
    */
   static byte[] readAllBytes(InputStream stream) throws IOException {
     int bytesRead = 0;
-    byte[] currentChunk = new byte[255];
+    byte[] currentChunk = new byte[1024];
     final List<byte[]> chunks = new ArrayList<byte[]>();
     while ((bytesRead = stream.read(currentChunk)) != -1) {
       chunks.add(copyOf(currentChunk, bytesRead));


### PR DESCRIPTION
To improve performance when reading a file into a byte array, we want to increase the chunk size, thereby limiting the length of the array that is uploaded to the server.