### PR TITLE
Upgrade okhttp3 from 3.12.1 to 4.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
     <!-- Dependencies -->
     <retrofit.version>2.9.0</retrofit.version>
     <gson.version>2.8.9</gson.version>
+    <okhttp.version>4.12.0</okhttp.version>
 
     <!-- Test Dependencies -->
     <commonsio.version>2.7</commonsio.version>
     <junit.version>4.13.1</junit.version>
     <kotlin.version>1.9.20</kotlin.version>
-    <okhttp.version>3.12.1</okhttp.version>
     <rxjava.version>2.2.5</rxjava.version>
     <android.version>4.1.1.4</android.version>
     <android.platform>16</android.platform>
@@ -107,7 +107,6 @@
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/test/kotlin/com/contentful/java/cma/AssetTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/AssetTests.kt
@@ -24,7 +24,7 @@ import com.contentful.java.cma.model.CMAAssetFile
 import com.contentful.java.cma.model.CMALink
 import com.contentful.java.cma.model.CMAType
 import com.google.gson.Gson
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -235,7 +235,7 @@ class AssetTests {
 
         // Request
         val request = server!!.takeRequest()
-        val url = HttpUrl.parse(server!!.url(request.path).toString())!!
+        val url = server!!.url(request.path!!).toString().toHttpUrlOrNull()!!
         assertEquals("1", url.queryParameter("skip"))
         assertEquals("2", url.queryParameter("limit"))
         assertEquals("foo", url.queryParameter("content_type"))
@@ -253,7 +253,7 @@ class AssetTests {
 
         // Request
         val request = server!!.takeRequest()
-        val url = HttpUrl.parse(server!!.url(request.path).toString())!!
+        val url = server!!.url(request.path!!).toString().toHttpUrlOrNull()!!
         assertEquals("1", url.queryParameter("skip"))
         assertEquals("2", url.queryParameter("limit"))
         assertEquals("foo", url.queryParameter("content_type"))
@@ -435,7 +435,7 @@ class AssetTests {
     fun testRetainsSysOnNetworkError() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setCoreCallFactory { throw IOException(it.url().toString(), IOException()) }
+                .setCoreCallFactory { throw IOException(it.url.toString(), IOException()) }
                 .build()
 
         val asset = CMAAsset().setVersion(31337)

--- a/src/test/kotlin/com/contentful/java/cma/CMAHttpExceptionTest.kt
+++ b/src/test/kotlin/com/contentful/java/cma/CMAHttpExceptionTest.kt
@@ -4,6 +4,8 @@ import com.contentful.java.cma.lib.TestUtils
 import com.contentful.java.cma.model.CMAHttpException
 import com.google.gson.Gson
 import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -253,7 +255,7 @@ class CMAHttpExceptionTest {
         return Response.Builder()
                 .request(request)
                 .body(
-                        ResponseBody.create(MediaType.parse("application/json"), body)
+                    body.toResponseBody("application/json".toMediaTypeOrNull())
                 )
                 .header(HEADER_RATE_LIMIT_HOUR_LIMIT, "1")
                 .header(HEADER_RATE_LIMIT_HOUR_REMAINING, "2")

--- a/src/test/kotlin/com/contentful/java/cma/ClientTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/ClientTests.kt
@@ -96,7 +96,7 @@ class ClientTests{
     fun testCoreCallbackRetrofitError() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setCoreCallFactory { throw RuntimeException(it.url().toString(), IOException()) }
+                .setCoreCallFactory { throw RuntimeException(it.url.toString(), IOException()) }
                 .build()
 
         val cb = TestCallback<CMAArray<CMASpace>>()
@@ -109,7 +109,7 @@ class ClientTests{
     fun testUploadCallbackRetrofitError() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setUploadCallFactory { throw RuntimeException(it.url().toString(), IOException()) }
+                .setUploadCallFactory { throw RuntimeException(it.url.toString(), IOException()) }
                 .build()
 
         val cb = TestCallback<CMAUpload>()
@@ -176,7 +176,7 @@ class ClientTests{
         // Request
         val recordedRequest = server!!.takeRequest()
 
-        assertTrue(recordedRequest.getHeader("User-Agent").contains(versionName))
+        assertTrue(recordedRequest.getHeader("User-Agent")!!.contains(versionName))
     }
 
     @test
@@ -188,7 +188,7 @@ class ClientTests{
         // Request
         val recordedRequest = server!!.takeRequest()
 
-        val actual = recordedRequest.getHeader("X-Contentful-User-Agent")
+        val actual = recordedRequest.getHeader("X-Contentful-User-Agent")!!
         assertTrue(actual.contains("sdk contentful-management.java/"))
         assertTrue(actual.contains("platform java/"))
         assertTrue(actual.contains("os"))

--- a/src/test/kotlin/com/contentful/java/cma/ContentTypeTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/ContentTypeTests.kt
@@ -25,7 +25,7 @@ import com.contentful.java.cma.model.CMAField
 import com.contentful.java.cma.model.CMAHttpException
 import com.contentful.java.cma.model.CMAType
 import com.google.gson.Gson
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -345,7 +345,7 @@ class ContentTypeTests{
 
         // Request
         val request = server!!.takeRequest()
-        val url = HttpUrl.parse(server!!.url(request.path).toString())!!
+        val url = server!!.url(request.path!!).toString().toHttpUrlOrNull()!!
         assertEquals("1", url.queryParameter("skip"))
         assertEquals("2", url.queryParameter("limit"))
         assertEquals("bar", url.queryParameter("foo"))
@@ -499,7 +499,7 @@ class ContentTypeTests{
     fun testRetainsSysOnNetworkError() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setCoreCallFactory { throw RuntimeException(it.url().toString(), IOException()) }
+                .setCoreCallFactory { throw RuntimeException(it.url.toString(), IOException()) }
                 .build()
 
         val contentType = CMAContentType().setVersion(31337)

--- a/src/test/kotlin/com/contentful/java/cma/EntryTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/EntryTests.kt
@@ -25,7 +25,7 @@ import com.contentful.java.cma.model.CMAMetadata
 import com.contentful.java.cma.model.CMATag
 import com.contentful.java.cma.model.CMAType
 import com.google.gson.Gson
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -298,7 +298,7 @@ class EntryTests {
 
         // Request
         val request = server!!.takeRequest()
-        val url = HttpUrl.parse(server!!.url(request.path).toString())!!
+        val url = server!!.url(request.path!!).toString().toHttpUrlOrNull()!!
         assertEquals("1", url.queryParameter("skip"))
         assertEquals("2", url.queryParameter("limit"))
         assertEquals("foo", url.queryParameter("content_type"))
@@ -452,7 +452,7 @@ class EntryTests {
     fun testRetainsSysOnNetworkError() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setCoreCallFactory { throw RuntimeException(it.url().toString(), IOException()) }
+                .setCoreCallFactory { throw RuntimeException(it.url.toString(), IOException()) }
                 .build()
 
         val entry = CMAEntry().setVersion(31337)

--- a/src/test/kotlin/com/contentful/java/cma/ModelTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/ModelTests.kt
@@ -159,7 +159,7 @@ class ModelTests {
                 .build()
 
         assertEquals("FAILED \n"
-                + "\tRequest{method=GET, url=https://example.com/, tags={}}\n"
+                + "\tRequest{method=GET, url=https://example.com/}\n"
                 + "\t↳ Header{}\n"
                 + "\tResponse{"
                 + "protocol=http/1.1, code=200, message=, url=https://example.com/}\n"

--- a/src/test/kotlin/com/contentful/java/cma/WebhookTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/WebhookTests.kt
@@ -289,7 +289,7 @@ class WebhookTests {
     fun testRetainsSysOnNetworkError() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setCoreCallFactory { throw IOException(it.url().toString(), IOException()) }
+                .setCoreCallFactory { throw IOException(it.url.toString(), IOException()) }
                 .build()
 
         val webhook = CMAWebhook().setVersion(31337)

--- a/src/test/kotlin/com/contentful/java/cma/e2e/WebhookE2E.kt
+++ b/src/test/kotlin/com/contentful/java/cma/e2e/WebhookE2E.kt
@@ -198,7 +198,7 @@ open class WebhookE2E : Base() {
     fun testRetainsSysOnNetworkErrorWebhook() {
         val badClient = CMAClient.Builder()
                 .setAccessToken("accesstoken")
-                .setCoreCallFactory { throw IOException(it.url().toString(), IOException()) }
+                .setCoreCallFactory { throw IOException(it.url.toString(), IOException()) }
                 .build()
 
         val webhook = CMAWebhook().setVersion(31337)


### PR DESCRIPTION
Hey everyone! When using this library I encountered some minor dependency issues, so I thought it might be time to upgrade the okhttp3 client from 3.12.1 (which was released on *Dec 23, 2018*) to the latest 4.12.0 (which was released a year ago, so no bleeding edge either).
Since the library migrated to Kotlin, `kotlin-stdlib-jdk8` is needed at compile-level scope as well.