### PR TITLE
fix: [JAVA-283] Add query param for fetchAllSnapshots endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Version [3.4.16] - [2024-12-16]
+- Changed: added fetchAllSnapshotsWithQuery method with query support
+
 ## Version [3.4.15] - [2024-09-16]
 - Changed: added scheduled actions API support
   
@@ -214,6 +217,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Initial release.
 
 [unreleased]: https://github.com/contentful/contentful-management.java/compare/cma-sdk-3.3.3...HEAD
+[3.4.16]: https://github.com/contentful/contentful-management.java/compare/v3.4.15...v3.4.16
 [3.4.15]: https://github.com/contentful/contentful-management.java/compare/v3.4.14...v3.4.15
 [3.4.14]: https://github.com/contentful/contentful-management.java/compare/v3.4.13...v3.4.14
 [3.4.13]: https://github.com/contentful/contentful-management.java/compare/v3.5.12...v3.4.13

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ Install the Contentful dependency:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.4.15</version>
+  <version>3.4.16</version>
 </dependency>
 ```
 
 * _Gradle_
 ```groovy
-compile 'com.contentful.java:cma-sdk:3.4.15'
+compile 'com.contentful.java:cma-sdk:3.4.16'
 ```
 
 This SDK requires Java 8 (or higher version).

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.4.16-SNAPSHOT</version>
+  <version>3.4.16</version>
   <packaging>jar</packaging>
 
   <name>cma-sdk</name>
@@ -20,7 +20,7 @@
     <url>http://github.com/contentful/contentful-management.java</url>
     <connection>scm:git:git://github.com/contentful/contentful-management.java.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/contentful/contentful-management.java.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>cma-sdk-3.4.16</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.4.16</version>
+  <version>3.4.17-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cma-sdk</name>
@@ -20,7 +20,7 @@
     <url>http://github.com/contentful/contentful-management.java</url>
     <connection>scm:git:git://github.com/contentful/contentful-management.java.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/contentful/contentful-management.java.git</developerConnection>
-    <tag>cma-sdk-3.4.16</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/com/contentful/java/cma/ModuleEntries.java
+++ b/src/main/java/com/contentful/java/cma/ModuleEntries.java
@@ -375,6 +375,30 @@ public class ModuleEntries extends AbsModule<ServiceEntries> {
   }
 
   /**
+   * Fetch all snapshots of an entry with additional query parameters.
+   *
+   * @param entry the entry whose snapshots are to be returned.
+   * @param query additional query parameters to refine the results.
+   * @return an array of snapshots matching the query.
+   * @throws IllegalArgumentException if entry is null.
+   * @throws IllegalArgumentException if entry's id is null.
+   * @throws IllegalArgumentException if entry's space id is null.
+   */
+  public CMAArray<CMASnapshot> fetchAllSnapshotsWithQuery(
+          CMAEntry entry, Map<String, String> query) {
+    assertNotNull(entry, "entry");
+    final String entryId = getResourceIdOrThrow(entry, "entry");
+    final String spaceId = getSpaceIdOrThrow(entry, "entry");
+    final String environmentId = entry.getEnvironmentId();
+
+    Map<String, String> enhancedQuery = DefaultQueryParameter.putIfNotSet(
+            query, DefaultQueryParameter.FETCH);
+
+    return service.fetchAllSnapshots(
+            spaceId, environmentId, entryId, enhancedQuery).blockingFirst();
+  }
+
+  /**
    * Fetch a specific snapshot of an entry.
    *
    * @param entry      the entry whose snapshot to be returned.
@@ -718,6 +742,29 @@ public class ModuleEntries extends AbsModule<ServiceEntries> {
       return defer(new RxExtensions.DefFunc<CMAArray<CMASnapshot>>() {
         @Override CMAArray<CMASnapshot> method() {
           return ModuleEntries.this.fetchAllSnapshots(entry);
+        }
+      }, callback);
+    }
+
+    /**
+     * Fetch all snapshots of an entry asynchronously with query parameters.
+     *
+     * @param entry    the entry whose snapshots are to be returned.
+     * @param query    additional query parameters to refine the results.
+     * @param callback the callback to be informed about success or failure.
+     * @return a callback for an array of snapshots.
+     * @throws IllegalArgumentException if entry is null.
+     * @throws IllegalArgumentException if entry's id is null.
+     * @throws IllegalArgumentException if entry's space id is null.
+     */
+    public CMACallback<CMAArray<CMASnapshot>> fetchAllSnapshotsWithQuery(
+            final CMAEntry entry,
+            final Map<String, String> query,
+            CMACallback<CMAArray<CMASnapshot>> callback) {
+      return defer(new RxExtensions.DefFunc<CMAArray<CMASnapshot>>() {
+        @Override
+        CMAArray<CMASnapshot> method() {
+          return ModuleEntries.this.fetchAllSnapshotsWithQuery(entry, query);
         }
       }, callback);
     }

--- a/src/main/java/com/contentful/java/cma/ServiceEntries.java
+++ b/src/main/java/com/contentful/java/cma/ServiceEntries.java
@@ -93,7 +93,14 @@ interface ServiceEntries {
   Flowable<CMAArray<CMASnapshot>> fetchAllSnapshots(
       @Path("space") String spaceId,
       @Path("environment") String environmentId,
-      @Path("entry") String entryId);
+      @Path("entry") String entryId,
+      @QueryMap Map<String, String> query);
+
+  @GET("spaces/{space}/environments/{environment}/entries/{entry}/snapshots")
+  Flowable<CMAArray<CMASnapshot>> fetchAllSnapshots(
+          @Path("space") String spaceId,
+          @Path("environment") String environmentId,
+          @Path("entry") String entryId);
 
   @PUT("spaces/{space}/environments/{environment}/entries/{entry}/published")
   Flowable<CMAEntry> publish(

--- a/src/test/kotlin/com/contentful/java/cma/EntryTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/EntryTests.kt
@@ -536,6 +536,37 @@ class EntryTests {
     }
 
     @test
+    fun testFetchAllSnapshotsWithQuery() {
+        val responseBody = TestUtils.fileToString("entry_snapshots_get_all_with_query.json")
+        server!!.enqueue(MockResponse().setResponseCode(200).setBody(responseBody))
+
+        val entry = CMAEntry()
+            .setId("entryId")
+            .setSpaceId("spaceId")
+            .setEnvironmentId("master")
+
+        val query = hashMapOf(
+            Pair("limit", "100"),
+            Pair("skip", "0")
+        )
+
+        val result = assertTestCallback(client!!.entries().async().fetchAllSnapshotsWithQuery(
+            entry, query, TestCallback()) as TestCallback)!!
+
+        val items = result.items
+        assertEquals(2, items.size)
+
+        val first = items[0]
+        assertEquals(CMAType.Snapshot, first.system.type)
+        assertTrue(first.snapshot is CMAEntry)
+
+        val recordedRequest = server!!.takeRequest()
+        val url = HttpUrl.parse(server!!.url(recordedRequest.path).toString())!!
+        assertEquals("100", url.queryParameter("limit"))
+        assertEquals("0", url.queryParameter("skip"))
+    }
+
+    @test
     fun testFetchOneSnapshot() {
         val responseBody = TestUtils.fileToString("entry_snapshots_get_one.json")
         server!!.enqueue(MockResponse().setResponseCode(200).setBody(responseBody))

--- a/src/test/resources/entry_snapshots_get_all_with_query.json
+++ b/src/test/resources/entry_snapshots_get_all_with_query.json
@@ -1,0 +1,239 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "items": [
+    {
+      "sys": {
+        "type": "Snapshot",
+        "snapshotType": "publish",
+        "snapshotEntityType": "Entry",
+        "id": "3v5AOdklBfe7preLva5OeZ",
+        "createdAt": "2017-04-25T09:13:31.601Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "updatedAt": "2017-04-25T09:13:31.601Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "<space_id>"
+          }
+        }
+      },
+      "snapshot": {
+        "fields": {
+          "name": {
+            "en-US": "A new entry",
+            "no-No": "Should not work!",
+            "blafoo": "That should also not work!"
+          },
+          "media": {
+            "en-US": {
+              "sys": {
+                "id": "2rz0d827SsUuUS40cEQcke",
+                "linkType": "Asset",
+                "type": "Link"
+              }
+            }
+          },
+          "link": {
+            "en-US": {
+              "sys": {
+                "id": "del_000000000000000000000000000000000000000000000000000000000000",
+                "linkType": "Entry",
+                "type": "Link"
+              }
+            }
+          },
+          "fields": {
+            "en-US": [
+              "as",
+              "df"
+            ]
+          },
+          "sys": {
+            "en-US": [
+              "tl",
+              "dr"
+            ]
+          }
+        },
+        "sys": {
+          "id": "34MftYTFmoOoKCqM48wcc8",
+          "type": "Entry",
+          "createdAt": "2017-04-24T10:42:08.851Z",
+          "createdBy": {
+            "sys": {
+              "type": "Link",
+              "linkType": "User",
+              "id": "<user_id>"
+            }
+          },
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "<space_id>"
+            }
+          },
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "deleteme"
+            }
+          },
+          "version": 49,
+          "updatedAt": "2017-04-25T09:13:31.586Z",
+          "updatedBy": {
+            "sys": {
+              "type": "Link",
+              "linkType": "User",
+              "id": "<user_id>"
+            }
+          },
+          "firstPublishedAt": "2017-04-24T10:42:51.814Z",
+          "publishedCounter": 2,
+          "publishedAt": "2017-04-25T09:13:31.586Z",
+          "publishedBy": {
+            "sys": {
+              "type": "Link",
+              "linkType": "User",
+              "id": "<user_id>"
+            }
+          },
+          "publishedVersion": 48
+        }
+      }
+    },
+    {
+      "sys": {
+        "type": "Snapshot",
+        "snapshotType": "publish",
+        "snapshotEntityType": "Entry",
+        "id": "5936CByxNGOX5Pxfwmb4vx",
+        "createdAt": "2017-04-24T10:42:51.831Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "updatedAt": "2017-04-24T10:42:51.831Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "<user_id>"
+          }
+        },
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "<space_id>"
+          }
+        }
+      },
+      "snapshot": {
+        "fields": {
+          "name": {
+            "en-US": "A new entry"
+          },
+          "media": {
+            "en-US": {
+              "sys": {
+                "id": "2rz0d827SsUuUS40cEQcke",
+                "linkType": "Asset",
+                "type": "Link"
+              }
+            }
+          },
+          "link": {
+            "en-US": {
+              "sys": {
+                "id": "del_000000000000000000000000000000000000000000000000000000000000",
+                "linkType": "Entry",
+                "type": "Link"
+              }
+            }
+          },
+          "fields": {
+            "en-US": [
+              "as",
+              "df"
+            ]
+          },
+          "sys": {
+            "en-US": [
+              "tl",
+              "dr"
+            ]
+          }
+        },
+        "sys": {
+          "id": "34MftYTFmoOoKCqM48wcc8",
+          "type": "Entry",
+          "createdAt": "2017-04-24T10:42:08.851Z",
+          "createdBy": {
+            "sys": {
+              "type": "Link",
+              "linkType": "User",
+              "id": "<user_id>"
+            }
+          },
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "<space_id>"
+            }
+          },
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "deleteme"
+            }
+          },
+          "version": 28,
+          "updatedAt": "2017-04-24T10:42:51.814Z",
+          "updatedBy": {
+            "sys": {
+              "type": "Link",
+              "linkType": "User",
+              "id": "<user_id>"
+            }
+          },
+          "firstPublishedAt": "2017-04-24T10:42:51.814Z",
+          "publishedCounter": 1,
+          "publishedAt": "2017-04-24T10:42:51.814Z",
+          "publishedBy": {
+            "sys": {
+              "type": "Link",
+              "linkType": "User",
+              "id": "<user_id>"
+            }
+          },
+          "publishedVersion": 27
+        }
+      }
+    }
+  ],
+  "skip": 0,
+  "limit": 100
+}


### PR DESCRIPTION
This PR introduces a new method, `fetchAllSnapshotsWithQuery`, to allow fetching snapshots with additional query parameters while preserving the existing `fetchAllSnapshots` method for backward compatibility.