### PR TITLE
fix: redact Authorization header in LogInterceptor [AIS-247]

### DIFF
--- a/src/main/java/com/contentful/java/cma/interceptor/LogInterceptor.java
+++ b/src/main/java/com/contentful/java/cma/interceptor/LogInterceptor.java
@@ -58,7 +58,11 @@ public class LogInterceptor implements Interceptor {
     return response;
   }
 
-  private static Headers redactHeaders(Headers headers) {
+  // Package-private for testing. Note: on okhttp >= 4.10, Headers.toString()
+  // already masks Authorization to "██", so this explicit redaction is
+  // defense-in-depth — it guarantees the token is stripped from the value
+  // regardless of okhttp's internal masking (e.g. if okhttp is pinned older).
+  static Headers redactHeaders(Headers headers) {
     Headers.Builder redacted = new Headers.Builder();
     for (int i = 0; i < headers.size(); i++) {
       String name = headers.name(i);

--- a/src/main/java/com/contentful/java/cma/interceptor/LogInterceptor.java
+++ b/src/main/java/com/contentful/java/cma/interceptor/LogInterceptor.java
@@ -62,7 +62,7 @@ public class LogInterceptor implements Interceptor {
     Headers.Builder redacted = new Headers.Builder();
     for (int i = 0; i < headers.size(); i++) {
       String name = headers.name(i);
-      if ("Authorization".equalsIgnoreCase(name)) {
+      if (AuthorizationHeaderInterceptor.HEADER_NAME.equalsIgnoreCase(name)) {
         redacted.add(name, "Bearer [REDACTED]");
       } else {
         redacted.add(name, headers.value(i));

--- a/src/main/java/com/contentful/java/cma/interceptor/LogInterceptor.java
+++ b/src/main/java/com/contentful/java/cma/interceptor/LogInterceptor.java
@@ -4,6 +4,7 @@ import com.contentful.java.cma.Logger;
 
 import java.io.IOException;
 
+import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -46,7 +47,7 @@ public class LogInterceptor implements Interceptor {
 
     long t1 = System.nanoTime();
     logger.log(String.format("Sending request %s on %s%n%s",
-        request.url(), chain.connection(), request.headers()));
+        request.url(), chain.connection(), redactHeaders(request.headers())));
 
     Response response = chain.proceed(request);
 
@@ -55,5 +56,18 @@ public class LogInterceptor implements Interceptor {
         response.request().url(), (t2 - t1) / NANOS_PER_SECOND, response.headers()));
 
     return response;
+  }
+
+  private static Headers redactHeaders(Headers headers) {
+    Headers.Builder redacted = new Headers.Builder();
+    for (int i = 0; i < headers.size(); i++) {
+      String name = headers.name(i);
+      if ("Authorization".equalsIgnoreCase(name)) {
+        redacted.add(name, "Bearer [REDACTED]");
+      } else {
+        redacted.add(name, headers.value(i));
+      }
+    }
+    return redacted.build();
   }
 }

--- a/src/test/kotlin/com/contentful/java/cma/interceptor/LogInterceptorTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/interceptor/LogInterceptorTests.kt
@@ -1,0 +1,73 @@
+package com.contentful.java.cma.interceptor
+
+import com.contentful.java.cma.Logger
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogInterceptorTests {
+    private lateinit var server: MockWebServer
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test fun testAuthorizationHeaderIsRedacted() {
+        val token = "super-secret-token"
+        val logs = mutableListOf<String>()
+        val logger = Logger { message -> logs.add(message) }
+
+        val client = OkHttpClient.Builder()
+                .addInterceptor(LogInterceptor(logger))
+                .build()
+
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        val request = Request.Builder()
+                .url(server.url("/"))
+                .header(AuthorizationHeaderInterceptor.HEADER_NAME, "Bearer $token")
+                .build()
+
+        client.newCall(request).execute().use { it.body?.string() }
+
+        val requestLog = logs.first { it.startsWith("Sending request") }
+
+        assertFalse(requestLog.contains(token), "Raw token must not appear in logs")
+        assertTrue(requestLog.contains("Bearer [REDACTED]"), "Redacted marker expected")
+    }
+
+    @Test fun testOtherHeadersAreStillLogged() {
+        val logs = mutableListOf<String>()
+        val logger = Logger { message -> logs.add(message) }
+
+        val client = OkHttpClient.Builder()
+                .addInterceptor(LogInterceptor(logger))
+                .build()
+
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        val request = Request.Builder()
+                .url(server.url("/"))
+                .header(AuthorizationHeaderInterceptor.HEADER_NAME, "Bearer secret")
+                .header("X-Custom-Header", "custom-value")
+                .build()
+
+        client.newCall(request).execute().use { it.body?.string() }
+
+        val requestLog = logs.first { it.startsWith("Sending request") }
+
+        assertTrue(requestLog.contains("X-Custom-Header: custom-value"),
+                "Non-authorization headers must still be logged")
+    }
+}

--- a/src/test/kotlin/com/contentful/java/cma/interceptor/LogInterceptorTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/interceptor/LogInterceptorTests.kt
@@ -1,6 +1,7 @@
 package com.contentful.java.cma.interceptor
 
 import com.contentful.java.cma.Logger
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -8,8 +9,8 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class LogInterceptorTests {
     private lateinit var server: MockWebServer
@@ -23,7 +24,36 @@ class LogInterceptorTests {
         server.shutdown()
     }
 
-    @Test fun testAuthorizationHeaderIsRedacted() {
+    // redactHeaders is the unit under test: it must replace the Authorization
+    // value with the redacted marker and leave everything else untouched. We
+    // assert on the header values directly (not Headers.toString(), which
+    // okhttp >= 4.10 masks to "██" by name regardless of value).
+    @Test fun testRedactHeadersReplacesAuthorizationValue() {
+        val redacted = LogInterceptor.redactHeaders(
+                Headers.Builder()
+                        .add(AuthorizationHeaderInterceptor.HEADER_NAME, "Bearer super-secret-token")
+                        .add("X-Custom-Header", "custom-value")
+                        .build()
+        )
+
+        assertEquals("Bearer [REDACTED]",
+                redacted[AuthorizationHeaderInterceptor.HEADER_NAME],
+                "Authorization value must be redacted")
+        assertEquals("custom-value", redacted["X-Custom-Header"],
+                "Non-authorization headers must be left untouched")
+    }
+
+    @Test fun testRedactHeadersMatchesHeaderNameCaseInsensitively() {
+        val redacted = LogInterceptor.redactHeaders(
+                Headers.Builder().add("authorization", "Bearer super-secret-token").build()
+        )
+
+        assertEquals("Bearer [REDACTED]", redacted["authorization"])
+    }
+
+    // End-to-end: drive a real request through the interceptor and confirm the
+    // raw token never reaches the log output.
+    @Test fun testTokenNeverAppearsInLog() {
         val token = "super-secret-token"
         val logs = mutableListOf<String>()
         val logger = Logger { message -> logs.add(message) }
@@ -37,29 +67,6 @@ class LogInterceptorTests {
         val request = Request.Builder()
                 .url(server.url("/"))
                 .header(AuthorizationHeaderInterceptor.HEADER_NAME, "Bearer $token")
-                .build()
-
-        client.newCall(request).execute().use { it.body?.string() }
-
-        val requestLog = logs.first { it.startsWith("Sending request") }
-
-        assertFalse(requestLog.contains(token), "Raw token must not appear in logs")
-        assertTrue(requestLog.contains("Bearer [REDACTED]"), "Redacted marker expected")
-    }
-
-    @Test fun testOtherHeadersAreStillLogged() {
-        val logs = mutableListOf<String>()
-        val logger = Logger { message -> logs.add(message) }
-
-        val client = OkHttpClient.Builder()
-                .addInterceptor(LogInterceptor(logger))
-                .build()
-
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
-
-        val request = Request.Builder()
-                .url(server.url("/"))
-                .header(AuthorizationHeaderInterceptor.HEADER_NAME, "Bearer secret")
                 .header("X-Custom-Header", "custom-value")
                 .build()
 
@@ -67,7 +74,6 @@ class LogInterceptorTests {
 
         val requestLog = logs.first { it.startsWith("Sending request") }
 
-        assertTrue(requestLog.contains("X-Custom-Header: custom-value"),
-                "Non-authorization headers must still be logged")
+        assertFalse(requestLog.contains(token), "Raw token must not appear in logs")
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `redactHeaders` private method that replaces the value of any `Authorization` header with `Bearer [REDACTED]` before passing to the logger
- Request headers are redacted; response headers are unchanged (they don't carry bearer tokens)
- No logging behavior is otherwise altered — consumers who set `BASIC` or `FULL` log level still see all other headers and request metadata

## Tickets

Closes AIS-247

## Test plan

- [ ] Build passes (`./gradlew build`)
- [ ] Enable `FULL` logging and confirm `Authorization` header no longer appears in logs
- [ ] Confirm all other request headers are still logged as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR improves testability of the LogInterceptor by making its `redactHeaders` method package-private and enhancing test coverage. The method serves as defense-in-depth to ensure Authorization header values are redacted to 'Bearer [REDACTED]' before logging, protecting sensitive bearer tokens regardless of the configured log level or okhttp version.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changes redactHeaders visibility from private static to package-private in LogInterceptor.java to enable direct unit testing; adds documentation comment explaining this is defense-in-depth against older okhttp versions</li>

<li>Rewrites testAuthorizationHeaderIsRedacted() as testRedactHeadersReplacesAuthorizationValue() to directly test the method instead of testing via log output</li>

<li>Adds testRedactHeadersMatchesHeaderNameCaseInsensitively() to verify 'authorization' header name matching regardless of case</li>

<li>Renames testOtherHeadersAreStillLogged() to testTokenNeverAppearsInLog() with updated assertions to confirm raw tokens never appear in log output</li>

</ul>
</details>

</div>