### PR TITLE
feat(usage): deprecate legacy periodic-usage endpoints [MOI-7252]

### DIFF
--- a/src/main/java/com/contentful/java/cma/ModuleOrganizationUsage.java
+++ b/src/main/java/com/contentful/java/cma/ModuleOrganizationUsage.java
@@ -37,7 +37,11 @@ public class ModuleOrganizationUsage extends AbsModule<ServiceOrganizationUsage>
      *
      * @param query the criteria to narrow down the search result.
      * @return {@link CMAUsage} result instance
+     * @deprecated The {@code GET /organizations/{organization_id}/organization_periodic_usages}
+     * endpoint is deprecated in favor of the new Usage API. It will be removed on
+     * 2027-02-28, after which requests will return 410 Gone.
      */
+    @Deprecated
     public CMAArray<CMAUsage> fetchAll(
             String organizationId,
             Map<String, String> query) {
@@ -66,7 +70,11 @@ public class ModuleOrganizationUsage extends AbsModule<ServiceOrganizationUsage>
 
 
          * @return {@link CMAUsage} result callback.
+         * @deprecated The {@code GET /organizations/{organization_id}/organization_periodic_usages}
+         * endpoint is deprecated in favor of the new Usage API. It will be removed on
+         * 2027-02-28, after which requests will return 410 Gone.
          */
+        @Deprecated
         public CMACallback<CMAArray<CMAUsage>> fetchAll(
                 String organizationId,
                 Map<String, String> query,

--- a/src/main/java/com/contentful/java/cma/ModuleSpaceUsage.java
+++ b/src/main/java/com/contentful/java/cma/ModuleSpaceUsage.java
@@ -37,7 +37,11 @@ public class ModuleSpaceUsage extends AbsModule<ServiceSpaceUsage> {
      * @param organizationId organization id for the request.
      * @param query the criteria to narrow down the search result.
      * @return {@link CMAUsage} result instance
+     * @deprecated The {@code GET /organizations/{organization_id}/space_periodic_usages}
+     * endpoint is deprecated in favor of the new Usage API. It will be removed on
+     * 2027-02-28, after which requests will return 410 Gone.
      */
+    @Deprecated
     public CMAArray<CMAUsage> fetchAll(
             String organizationId,
             Map<String, String> query) {
@@ -66,7 +70,11 @@ public class ModuleSpaceUsage extends AbsModule<ServiceSpaceUsage> {
          * @param organizationId organization id for the request.
          * @param query possible parameters of the request.
          * @return {@link CMAUsage} result callback.
+         * @deprecated The {@code GET /organizations/{organization_id}/space_periodic_usages}
+         * endpoint is deprecated in favor of the new Usage API. It will be removed on
+         * 2027-02-28, after which requests will return 410 Gone.
          */
+        @Deprecated
         public CMACallback<CMAArray<CMAUsage>> fetchAll(
                 String organizationId,
                 Map<String, String> query,

--- a/src/main/java/com/contentful/java/cma/ServiceOrganizationUsage.java
+++ b/src/main/java/com/contentful/java/cma/ServiceOrganizationUsage.java
@@ -11,11 +11,23 @@ import java.util.Map;
 
 public interface ServiceOrganizationUsage {
 
+    /**
+     * @deprecated The {@code GET /organizations/{organization_id}/organization_periodic_usages}
+     * endpoint is deprecated in favor of the new Usage API. It will be removed on
+     * 2027-02-28, after which requests will return 410 Gone.
+     */
+    @Deprecated
     @GET("organizations/{organization_id}/organization_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId
     );
 
+    /**
+     * @deprecated The {@code GET /organizations/{organization_id}/organization_periodic_usages}
+     * endpoint is deprecated in favor of the new Usage API. It will be removed on
+     * 2027-02-28, after which requests will return 410 Gone.
+     */
+    @Deprecated
     @GET("organizations/{organization_id}/organization_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId,

--- a/src/main/java/com/contentful/java/cma/ServiceSpaceUsage.java
+++ b/src/main/java/com/contentful/java/cma/ServiceSpaceUsage.java
@@ -10,11 +10,23 @@ import retrofit2.http.QueryMap;
 import java.util.Map;
 
 public interface ServiceSpaceUsage {
+    /**
+     * @deprecated The {@code GET /organizations/{organization_id}/space_periodic_usages}
+     * endpoint is deprecated in favor of the new Usage API. It will be removed on
+     * 2027-02-28, after which requests will return 410 Gone.
+     */
+    @Deprecated
     @GET("organizations/{organization_id}/space_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId
     );
 
+    /**
+     * @deprecated The {@code GET /organizations/{organization_id}/space_periodic_usages}
+     * endpoint is deprecated in favor of the new Usage API. It will be removed on
+     * 2027-02-28, after which requests will return 410 Gone.
+     */
+    @Deprecated
     @GET("organizations/{organization_id}/space_periodic_usages")
     Flowable<CMAArray<CMAUsage>> fetchAll(
             @Path("organization_id") String organizationId,

--- a/src/main/java/com/contentful/java/cma/model/CMAUsage.java
+++ b/src/main/java/com/contentful/java/cma/model/CMAUsage.java
@@ -2,6 +2,13 @@ package com.contentful.java.cma.model;
 
 import java.util.LinkedHashMap;
 
+/**
+ * @deprecated The {@code GET /organizations/{organization_id}/organization_periodic_usages}
+ * and {@code GET /organizations/{organization_id}/space_periodic_usages} endpoints are
+ * deprecated in favor of the new Usage API. They will be removed on 2027-02-28, after
+ * which requests will return 410 Gone.
+ */
+@Deprecated
 public class CMAUsage extends CMAResource {
     private String unitOfMeasure;
     private UsageMetric metric;


### PR DESCRIPTION
Ticket: https://contentful.atlassian.net/browse/MOI-7252 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR deprecates the legacy organization_periodic_usages and space_periodic_usages API endpoints in the Contentful Management Java SDK by adding @Deprecated annotations and Javadoc warnings across five files, indicating these endpoints will be removed on 2027-02-28.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added @Deprecated annotation and deprecation Javadoc to both sync and async fetchAll methods in ModuleOrganizationUsage.java, covering the deprecated GET /organizations/{organization_id}/organization_periodic_usages endpoint</li>

<li>Added @Deprecated annotation and deprecation Javadoc to both sync and async fetchAll methods in ModuleSpaceUsage.java, covering the deprecated GET /organizations/{organization_id}/space_periodic_usages endpoint</li>

<li>Added @Deprecated annotation and deprecation Javadoc to all fetchAll method overloads in ServiceOrganizationUsage.java Retrofit interface definitions</li>

<li>Added @Deprecated annotation and deprecation Javadoc to all fetchAll method overloads in ServiceSpaceUsage.java Retrofit interface definitions</li>

<li>Deprecated the CMAUsage model class as it is backed by the legacy endpoints being phased out</li>

</ul>
</details>

</div>