### PR TITLE
Release v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## Version [3.5.0] - [2026-08-18]
+- Changed: deprecated legacy periodic-usage endpoints
+- Changed: redact Authorization header value when logging requests
+
 ## Version [3.4.19] - [2025-03-28]
 - Changed: fixed issue with taxonomy serializing
   

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Install the Contentful dependency:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.4.23</version>
+  <version>3.5.0</version>
 </dependency>
 ```
 
 * _Gradle_
 ```groovy
-compile 'com.contentful.java:cma-sdk:3.4.23'
+compile 'com.contentful.java:cma-sdk:3.5.0'
 ```
 
 This SDK requires Java 8 (or higher version).

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.4.23</version>
+  <version>3.5.0</version>
   <packaging>jar</packaging>
 
   <name>cma-sdk</name>


### PR DESCRIPTION
Release `com.contentful.java:cma-sdk` 3.5.0 (previous release: 3.4.23).

## Contents

| Change | PR |
| --- | --- |
| `feat(usage)`: deprecate legacy periodic-usage endpoints [MOI-7252] | #224 |
| `fix`: redact Authorization header in `LogInterceptor` [AIS-247] | #212 |
| `chore`: set up Renovate for dependency updates [MEC-3447] | #211 |
| `chore`: add devcontainer contributor workflow [DX-822] | #209 |
| `chore`: route CI alerts to sdk-bots channel | #208 |
| `docs`: seed Golden Context [DX-1029] | — |

## Why minor, not patch

This repo has historically shipped features as patch bumps (3.4.17 added the whole Taxonomy API). This one goes to 3.5.0 because it deprecates public API — a signal consumers should see in the version. The change is additive (`@Deprecated` annotations, 47 insertions / 0 deletions), so nothing breaks.

## Changes in this PR

- `pom.xml` — project version 3.4.23 → 3.5.0
- `README.md` — Maven and Gradle coordinate snippets
- `CHANGELOG.md` — new 3.5.0 entry

## Verification

`./mvnw clean verify` on Zulu 8 (arm64), matching the Temurin 8 used in CI:

- 333 tests, 0 failures, 0 errors
- All 5 artifacts GPG-signed and verified against the shared release key `AF790D3C5A44D643` — the same key that signed `java-sdk` 10.6.0
- Artifacts produced: `.jar`, `-sources.jar`, `-javadoc.jar`, `-jar-with-dependencies.jar`, `.pom`

## Note for a follow-up

`CHANGELOG.md` has no entries for 3.4.20 through 3.4.23, all of which shipped to Maven Central. Deliberately left out of scope here to keep this PR reviewable, but worth backfilling.

## After merge

Per the [Java & Android SDK Runbook](https://contentful.atlassian.net/wiki/spaces/ECO/pages/5995429889/Java+Android+SDK+Runbook): `release:prepare` → `release:perform` → promote in the Central Portal → GitHub release → publish javadoc to `gh-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOI-7252]: https://contentful.atlassian.net/browse/MOI-7252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-247]: https://contentful.atlassian.net/browse/AIS-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MEC-3447]: https://contentful.atlassian.net/browse/MEC-3447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-822]: https://contentful.atlassian.net/browse/DX-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1029]: https://contentful.atlassian.net/browse/DX-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR prepares the release of version 3.5.0 for the Contentful CMA Java SDK. The release marks the deprecation of legacy periodic-usage endpoints and includes a security fix for the LogInterceptor to redact Authorization header values. The version bump from 3.4.23 to 3.5.0 signals to consumers that public API deprecation is included, which warrants a minor version increment rather than a patch.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>pom.xml - Updated project version from 3.4.23 to 3.5.0</li>

<li>CHANGELOG.md - Added new 3.5.0 release entry documenting: legacy periodic-usage endpoint deprecation and Authorization header redaction in logging</li>

<li>README.md - Updated Maven and Gradle dependency coordinate snippets to reference version 3.5.0</li>

</ul>
</details>

</div>