### PR TITLE
fix: restore developers metadata required by Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,16 @@
     <url>http://contentful.com</url>
   </organization>
 
+  <developers>
+    <developer>
+      <id>contentful-dx</id>
+      <name>Contentful Developer Experience</name>
+      <email>prd-ecosystem-dx@contentful.com</email>
+      <organization>Contentful</organization>
+      <organizationUrl>https://www.contentful.com</organizationUrl>
+    </developer>
+  </developers>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>


### PR DESCRIPTION
## Why

While deploying `3.5.0` to Sonatype Central, validation failed:

```
Deployment 1d2ac64d-4a7b-405a-a2ae-87d2088e5cc7 failed
pkg:maven/com.contentful.java/cma-sdk@3.5.0:
 - Developers information is missing
```

Commit 2672ceb ("Release/3.4.23 to master", #207) removed the `<developers>` block from `pom.xml` alongside unrelated dependency bumps (okhttp 3.12.1→4.12.0, android.platform 16→21, kotlin-stdlib). Published `3.4.23` still has the block, so it was deployed before that removal landed — this has been latent ever since and blocks every future release.

`contentful.java` (the CDA SDK) still has its block intact, so only this repo regressed.

## What

Restores `<developers>` in its original position (after `<organization>`, before `<properties>`), as a team entry rather than an individual contributor so it doesn't go stale again.

## Verification

Re-ran `./mvnw -B clean deploy` locally with this change — Central Portal validation passes:

```
Uploaded bundle successfully, deploymentId: 85a85180-27c2-43ba-9cb7-190c622ddcd9
Deployment 85a85180-27c2-43ba-9cb7-190c622ddcd9 has been validated.
```

The deployment is validated but **not yet published** (`autoPublish` is false), so nothing is live on Central until it's promoted manually. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR restores the `<developers>` metadata block in pom.xml that was accidentally removed during a previous release's dependency updates, which has been blocking Maven Central deployment since version 3.4.23. The fix uses a team-based entry (Contentful Developer Experience) instead of individual contributors to ensure the metadata remains current and prevents future staleness.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Restores `<developers>` section in pom.xml (lines 37-45) with team-based entry to resolve Sonatype Central Portal validation error that was blocking Maven Central deployment</li>

<li>Replaces individual contributor entry with team identity (id: contentful-dx, email: prd-ecosystem-dx@contentful.com) to prevent staleness on personnel changes</li>

<li>Positions developers block after `<organization>` and before `<properties>` following Maven POM conventions</li>

</ul>
</details>

</div>